### PR TITLE
Decouple dish_name from meal_type — fix wrong "Breakfast" naming

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -119,9 +119,10 @@ Picture one user message: a photo of a salad with caption *"for lunch"*.
 4. Back in `handle_photo`, items are passed to `database.log_meal_items`.
    That function classifies `meal_type` **once** for the whole batch
    (caption-detected if Opus emitted one, else the time-of-day + 90-min
-   rule), then inserts one meal row per ingredient. If the caption didn't
-   supply a `meal_type` and the batch landed as breakfast, any "Plate"
-   placeholder `dish_name` is renamed "Breakfast".
+   rule), then inserts one meal row per ingredient. `dish_name` and
+   `meal_type` are independent fields — `dish_name` describes what's on
+   the plate, `meal_type` describes when it was eaten. The system does
+   not rename `dish_name` based on `meal_type` (or vice versa).
 5. A short text summary of what was logged (`[Photo logged (photo): Greens
    60g (30 kcal), …]`) is appended to the `conversation_messages` table so
    later text turns like *"actually 600g"* have a referent.
@@ -492,9 +493,11 @@ from becoming its own siblings' "prior meal" mid-insert.
 - **Tier 1 wins:** if any item dict has `meal_type` set (from caption
   detection), that becomes the batch's `meal_type`. Otherwise
   `classify_meal_type` runs against state BEFORE the batch.
-- **Post-process:** if Claude used "Plate" as a placeholder `dish_name`
-  and the batch was classified as breakfast, every "Plate" → "Breakfast"
-  rename happens in one UPDATE.
+- **No `dish_name` post-processing.** `dish_name` and `meal_type` are
+  independent fields with separate jobs (see §3.3 and the analyzer
+  prompts in §7.1). The analyzer is the single source of truth for
+  naming; `log_meal_items` does not adjust `dish_name` based on
+  `meal_type`.
 
 **Called from:** `telegram_bot.handle_photo`, `telegram_bot.handle_text`
 (`log_text` and `add_items` branches).
@@ -742,15 +745,28 @@ spells out the JSON output schema and the rules the model must follow.
 nutrition/UX behaviour you want to change probably lives here.
 
 - `FOOD_SYSTEM_PROMPT` — used by `analyze_food_photo`. Identifies every
-  distinct component of a plate, names the dish, applies the **single-item
-  rule** (one apple → `dish_name="Apple"`, not `"Snack"`), embeds gram
-  weights, handles countable multi-piece items with the `× Npcs` marker.
+  distinct component of a plate, names the dish, embeds gram weights,
+  handles countable multi-piece items with the `× Npcs` marker. Two
+  naming rules:
+    - **Rule 1 (single standalone item):** one apple →
+      `dish_name = "Apple"`, regardless of caption.
+    - **Rule 2 (composed dish, 2+ items):** descriptive name where
+      possible (`"Caesar Salad"`, `"Udon Bowl"`, `"Avocado Toast"`),
+      otherwise size-prefixed `"Small Plate"` / `"Medium Plate"` /
+      `"Big Plate"` by ingredient count. Applies regardless of caption.
+  The prompt's anti-hallucination clause forbids the words
+  `"Breakfast"`, `"Lunch"`, `"Dinner"`, or `"Snack"` inside `dish_name`
+  — those words belong in the `meal_type` field, never the `dish_name`.
+  `meal_type` comes ONLY from the user's caption; if the caption is
+  silent, `meal_type` is `null` and `database.classify_meal_type`
+  fills it in from time of day (see §3.3).
 - `LABEL_SYSTEM_PROMPT` — used by `analyze_label_photo`. Reads the
   nutrition table, scales macros to the user's portion size (caption →
   label serving → realistic per-product default in that order), always
   embeds a portion weight in the dish string.
-- `TEXT_SYSTEM_PROMPT` — used by `analyze_text`. Same shape as the photo
-  prompt but for plain-text descriptions.
+- `TEXT_SYSTEM_PROMPT` — used by `analyze_text`. Same naming rules,
+  same anti-hallucination clause as the photo prompt, applied to
+  plain-text descriptions instead of images.
 - `CORRECTION_SYSTEM_PROMPT` — used by `resolve_correction`. The
   *"how to interpret a correction"* rulebook; lists eight action types
   (`update`, `update_many`, `delete`, `delete_many`, `scale_dish`,

--- a/analyzer.py
+++ b/analyzer.py
@@ -59,17 +59,35 @@ Each element must have exactly these keys:
                       → dish_name = "Salad" (NOT "Lunch")
                     One coffee, one yogurt, one protein bar → dish_name = dish
 
-                RULE 2 — COMPOSED BREAKFAST (2+ items, caption says breakfast):
-                    ≤ 3 ingredients  → "Small Breakfast"
-                    4–6 ingredients  → "Medium Breakfast"
-                    ≥ 7 ingredients  → "Big Breakfast"
-                  If the caption doesn't say "breakfast", use "Small/Medium/Big Plate"
-                  and the system will correct it later.
+                RULE 2 — COMPOSED DISH (2+ items):
+                  dish_name describes WHAT'S ON THE PLATE, never when it
+                  was eaten.
+                  - First, try a descriptive food name based on the contents:
+                      "Caesar Salad", "Udon Bowl", "Avocado Toast",
+                      "Chicken Power Bowl", "Greek Yogurt Bowl",
+                      "Oatmeal Bowl", "Pasta Carbonara", etc.
+                  - If the items don't form a recognizable named dish
+                    (random mix of things), fall back to a size-prefixed
+                    "Plate" by ingredient count:
+                      ≤ 3 ingredients  → "Small Plate"
+                      4–6 ingredients  → "Medium Plate"
+                      ≥ 7 ingredients  → "Big Plate"
+                  This applies REGARDLESS of caption — same dish_name
+                  approach whether the caption mentions a meal or not.
 
-                RULE 3 — COMPOSED LUNCH / DINNER / SNACK (2+ items):
-                  Use a descriptive food name, short and clear.
-                    e.g. "Chicken Power Bowl", "Caesar Salad", "Udon Bowl", "Oat Bowl"
-                  Never use "Lunch", "Dinner", or "Snack" as the dish_name.
+                CRITICAL ANTI-HALLUCINATION RULE — dish_name and meal_type
+                are SEPARATE fields with separate jobs:
+                  - dish_name = WHAT'S ON THE PLATE (food). NEVER write
+                    "Breakfast", "Lunch", "Dinner", or "Snack" inside
+                    dish_name — even if the food visually looks
+                    breakfast-y (eggs, oatmeal, coffee, yogurt, toast),
+                    lunch-y, or dinner-y. The dish_name is always about
+                    the food itself, never about meal time.
+                  - meal_type = WHEN IT WAS EATEN. Comes ONLY from the
+                    user's caption. If the caption is silent about meal
+                    time, set meal_type = null. Do NOT infer meal_type
+                    from what the food visually resembles — the system
+                    fills it in from time of day when meal_type is null.
   dish        — string, the individual ingredient or component. Keep it SHORT.
                 ALWAYS include a gram (or ml) weight for every ingredient — estimate
                 if not visible. Whole items get typical weights (egg ≈ 60g, small
@@ -105,7 +123,7 @@ Each element must have exactly these keys:
   carbs_g     — number
   sugar_g     — number
   confidence  — one of: "high", "medium", "low"
-  meal_type   — detect from the caption: "breakfast", "lunch", "dinner", "snack", or null if not mentioned
+  meal_type   — comes ONLY from the user's caption: "breakfast", "lunch", "dinner", "snack", or null if the caption is silent about meal time. Never infer from photo content (see CRITICAL ANTI-HALLUCINATION RULE above).
 
 Example (a plate of udon + a side apple):
 [
@@ -115,10 +133,24 @@ Example (a plate of udon + a side apple):
   {"dish_name": "Apple", "dish": "Apple 120g", "kcal": 80, "protein_g": 0, "fat_g": 0, "carbs_g": 21, "sugar_g": 15, "confidence": "high", "meal_type": "lunch"}
 ]
 
-Example with a countable multi-piece item — breakfast with 2 fried eggs + avocado:
+Example with a countable multi-piece item — caption "for breakfast", 2 fried eggs + avocado:
 [
-  {"dish_name": "Medium Breakfast", "dish": "Fried egg × 2pcs 120g", "kcal": 180, "protein_g": 12, "fat_g": 14, "carbs_g": 0, "sugar_g": 0, "confidence": "high", "meal_type": "breakfast"},
-  {"dish_name": "Medium Breakfast", "dish": "Avocado 80g", "kcal": 128, "protein_g": 2, "fat_g": 12, "carbs_g": 7, "sugar_g": 1, "confidence": "high", "meal_type": "breakfast"}
+  {"dish_name": "Eggs and Avocado", "dish": "Fried egg × 2pcs 120g", "kcal": 180, "protein_g": 12, "fat_g": 14, "carbs_g": 0, "sugar_g": 0, "confidence": "high", "meal_type": "breakfast"},
+  {"dish_name": "Eggs and Avocado", "dish": "Avocado 80g", "kcal": 128, "protein_g": 2, "fat_g": 12, "carbs_g": 7, "sugar_g": 1, "confidence": "high", "meal_type": "breakfast"}
+]
+
+Example — same eggs and avocado photo but NO caption:
+[
+  {"dish_name": "Eggs and Avocado", "dish": "Fried egg × 2pcs 120g", "kcal": 180, "protein_g": 12, "fat_g": 14, "carbs_g": 0, "sugar_g": 0, "confidence": "high", "meal_type": null},
+  {"dish_name": "Eggs and Avocado", "dish": "Avocado 80g", "kcal": 128, "protein_g": 2, "fat_g": 12, "carbs_g": 7, "sugar_g": 1, "confidence": "high", "meal_type": null}
+]
+Note: dish_name describes the food, not the meal time. meal_type is null because the caption was silent — the system fills it in from time of day. Do NOT infer "breakfast" from the photo content.
+
+Example — random plate of 5 items, no caption (no obvious named dish):
+[
+  {"dish_name": "Medium Plate", "dish": "Boiled egg 60g", ..., "meal_type": null},
+  {"dish_name": "Medium Plate", "dish": "Cheese 25g", ..., "meal_type": null},
+  ... (5 ingredients total)
 ]
 
 If you genuinely cannot identify anything, return an empty array [].
@@ -192,13 +224,30 @@ IMPORTANT: Reply with ONLY a JSON array. Each element must have these keys:
                       → dish_name = "Oatmeal" (NOT "Small Breakfast")
                     "a salad for lunch" → dish_name = "Salad" (NOT "Lunch")
 
-                RULE 2 — COMPOSED BREAKFAST (2+ items, user says breakfast):
-                    ≤3 → "Small Breakfast", 4–6 → "Medium Breakfast", ≥7 → "Big Breakfast"
-                  If not clear it's breakfast, use "Small/Medium/Big Plate".
+                RULE 2 — COMPOSED DISH (2+ items):
+                  dish_name describes WHAT WAS EATEN, never when.
+                  - First, try a descriptive food name based on the
+                    contents: "Chicken Bowl", "Pasta Carbonara",
+                    "Caesar Salad", "Oatmeal Bowl", "Avocado Toast", etc.
+                  - If the items don't form a recognizable named dish
+                    (random mix of things), fall back to a size-prefixed
+                    "Plate" by ingredient count:
+                      ≤3 → "Small Plate", 4–6 → "Medium Plate", ≥7 → "Big Plate"
+                  This applies REGARDLESS of whether the user mentions a
+                  meal time — same dish_name approach either way.
 
-                RULE 3 — COMPOSED LUNCH / DINNER / SNACK (2+ items):
-                  Descriptive food name (e.g. "Chicken Bowl", "Pasta").
-                  Never use "Lunch", "Dinner", or "Snack" as dish_name.
+                CRITICAL ANTI-HALLUCINATION RULE — dish_name and meal_type
+                are SEPARATE fields:
+                  - dish_name = WHAT WAS EATEN (food). NEVER write
+                    "Breakfast", "Lunch", "Dinner", or "Snack" inside
+                    dish_name — even if the user mentions one of those
+                    words and even if the food sounds breakfast-y. The
+                    dish_name is always about the food itself.
+                  - meal_type = WHEN. Comes ONLY from the user's words.
+                    If the user doesn't mention a meal time, set
+                    meal_type = null. Do NOT infer meal_type from what
+                    the food sounds like — the system fills it in from
+                    time of day when meal_type is null.
   dish        — the individual ingredient, SHORT + always include a gram/ml weight.
                 Estimate weight for whole items (egg ≈ 60g, banana ≈ 120g, small avocado half ≈ 70g).
                 "Rolled oats 80g" → "Oats 80g", "Banana 1 medium" → "Banana 120g",
@@ -218,12 +267,15 @@ IMPORTANT: Reply with ONLY a JSON array. Each element must have these keys:
                 row with the total weight — never use "× Npcs" for bulk foods.
   kcal, protein_g, fat_g, carbs_g, sugar_g, confidence, meal_type
 
-For meal_type detect it from the user's words:
+For meal_type, read the user's actual words (NOT the food they mention):
 - "for breakfast", "breakfast" → "breakfast"
 - "for lunch", "lunch" → "lunch"
 - "for dinner", "dinner", "supper" → "dinner"
 - "snack", "quick bite" → "snack"
-- If not mentioned, use null (the app will guess from time of day)
+- If not mentioned, use null. The app fills it in from time of day.
+  Do NOT infer meal_type from what the food sounds like (oatmeal does
+  not automatically mean breakfast; pasta does not automatically mean
+  dinner). See the CRITICAL ANTI-HALLUCINATION RULE above.
 
 Example — "I had oatmeal with banana and honey, and also a coffee":
 [

--- a/database.py
+++ b/database.py
@@ -455,22 +455,11 @@ def log_meal_items(user_id: int, items: list[dict], source: str = "photo") -> li
         )
         ids.append(meal_id)
 
-    # If Claude used "Plate" as placeholder (no caption meal_type) and the
-    # batch was classified as breakfast, replace "Plate" with "Breakfast".
-    # Only applies to breakfast — lunch/dinner/snack use descriptive names.
-    if ids and batch_meal_type == "breakfast":
-        conn = get_conn()
-        with conn:
-            conn.execute(
-                """UPDATE meals SET dish_name = REPLACE(dish_name, 'Plate', 'Breakfast')
-                   WHERE id IN ({})
-                     AND dish_name LIKE '%Plate%'""".format(
-                    ",".join("?" * len(ids))
-                ),
-                (*ids,)
-            )
-        conn.close()
-
+    # Note: there's deliberately no post-process that adjusts dish_name
+    # based on batch_meal_type. As of issue #13, dish_name and meal_type
+    # are independent fields — dish_name describes WHAT'S ON THE PLATE
+    # and meal_type describes WHEN IT WAS EATEN. The analyzer prompt is
+    # the single source of truth for naming; we don't override it here.
     return ids
 
 


### PR DESCRIPTION
Issue: photos logged at e.g. 14:00 with no caption were getting named "Small Breakfast" with meal_type=breakfast — wildly wrong. Two layers to the bug: (a) the analyzer was over-applying its breakfast naming rule because the prompt's Rule 2 led with "BREAKFAST" naming and the "if no caption use Plate" branch was a tucked-in caveat; (b) the analyzer was inferring meal_type from photo content rather than from the caption alone; (c) there was no defensive code to undo a wrongly- named dish, only a one-directional "Plate → Breakfast" upgrade.

Fix: dish_name and meal_type become independent fields. dish_name describes WHAT'S ON THE PLATE; meal_type describes WHEN. Neither leaks into the other.

Prompts (FOOD_SYSTEM_PROMPT and TEXT_SYSTEM_PROMPT both updated):
  - Rules 2 and 3 merged into a single Rule 2 (composed dish, 2+ items): descriptive name where possible (Caesar Salad, Udon Bowl, etc.), otherwise Small/Medium/Big Plate by ingredient count. Applies regardless of caption.
  - New CRITICAL ANTI-HALLUCINATION RULE: dish_name MUST NEVER contain the words "Breakfast", "Lunch", "Dinner", or "Snack", regardless of what the food visually resembles. meal_type comes ONLY from caption and stays null when caption is silent — never inferred from photo content.
  - Removed the "the system will correct it later" phrasing that licensed the model to be loose.
  - Updated examples in FOOD prompt to demonstrate the new naming (descriptive + null meal_type for caption-silent photos).

Code (database.log_meal_items):
  - Removed the post-process that renamed "Plate" → "Breakfast" when the time-window classifier landed on breakfast. With the new naming rules dish_name and meal_type are decoupled, so this one-directional upgrade is no longer needed (and the missing inverse downgrade was the bug).

Architecture doc (ARCHITECTURE.md):
  - §2 lifecycle: removed the "Plate placeholder rename" sentence; added the dish_name/meal_type independence note.
  - §5.4 log_meal_items: removed the "Post-process Plate → Breakfast" bullet; added a "no dish_name post-processing" note explaining why.
  - §7.1 system prompts: described the new Rule 1 / Rule 2 structure and the anti-hallucination clause, for both photo and text prompts.

Closes #13