### PR TITLE
PR A — Withings weight sync plumbing (schema + sync + OAuth bootstrap)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,3 +6,16 @@ ANTHROPIC_API_KEY=your_anthropic_api_key_here
 
 # Optional: custom path for the SQLite database
 # NUTRITION_DB_PATH=nutrition.db
+
+# Optional: OpenAI key for Whisper voice transcription. Without this, voice
+# messages return an error message instead of being transcribed.
+# OPENAI_API_KEY=your_openai_api_key_here
+
+# ── Withings API integration (optional — for automated weight sync) ──────────
+# Register a developer app at https://developer.withings.com/ to get these.
+# Then run `python setup_withings.py --user <your_telegram_id>` once to
+# authorize. The hourly withings_sync.py cron job uses these to pull weight
+# readings into the `weight_readings` table.
+# WITHINGS_CLIENT_ID=your_withings_client_id
+# WITHINGS_CLIENT_SECRET=your_withings_consumer_secret
+# WITHINGS_REDIRECT_URI=http://localhost:8765/callback

--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,9 @@ ingest.log
 lint.log
 contradictions.log
 
+# Withings sync debug log — local/server only
+withings.log
+
 # Python
 __pycache__/
 *.py[cod]

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -253,6 +253,43 @@ text summaries so follow-ups can reference them. The reader returns the
 larger of "last 16 hours" or "last 20 messages" to avoid a midnight cliff.
 Anything older than 14 days is purged by the Saturday cron.
 
+#### `weight_readings`
+
+Raw weight history — one row per weighing (typically multiple per day).
+Populated by the hourly `withings_sync.py` cron job pulling from the
+Withings Health API. After each insert, `daily_stats.weight_kg` is
+automatically refreshed to the **minimum** reading of that calendar day
+(the morning-low convention), so all existing summary code keeps seeing
+"one weight per day."
+
+| Column | Type | Meaning |
+| --- | --- | --- |
+| `id` | INTEGER PK | Auto-incremented. |
+| `user_id` | INTEGER FK | |
+| `measured_at` | TEXT | ISO timestamp from the source (Withings). |
+| `weight_kg` | REAL | The reading, in kilograms. |
+| `source` | TEXT | `'withings_api'` initially; future-proofed for other sources. |
+| `inserted_at` | TEXT | Default `datetime('now')`. |
+
+`UNIQUE(user_id, measured_at)` dedups when the polling script catches the
+same Withings reading twice.
+
+#### `withings_auth`
+
+OAuth tokens for the Withings Health API. One row per user who has
+authorized the bot to read their data. Populated once by
+`setup_withings.py` (interactive bootstrap), refreshed automatically by
+`withings_sync.py` when the access token expires.
+
+| Column | Type | Meaning |
+| --- | --- | --- |
+| `user_id` | INTEGER PK | FK → `users`. |
+| `access_token` | TEXT | Bearer token (~3h lifetime). |
+| `refresh_token` | TEXT | Long-lived. Used to mint new access tokens. |
+| `expires_at` | TEXT | ISO timestamp when access_token expires. |
+| `withings_user_id` | TEXT | Withings' internal user ID, for reference. |
+| `updated_at` | TEXT | Default `datetime('now')`. |
+
 ### 3.2 The wiki on disk
 
 Each user has a folder at `wiki/user_<user_id>/` containing five markdown
@@ -1343,6 +1380,60 @@ doesn't reprocess old queued messages.
 
 ---
 
+## 11A. Module reference: `withings_sync.py` + `setup_withings.py`
+
+Two small scripts that handle the Withings Health API integration. Issue
+#7 introduced these to pull weight readings into `weight_readings`
+automatically.
+
+### `setup_withings.py` — one-time OAuth bootstrap
+
+Interactive script run once per user (typically just you, the owner of
+the bot). Walks through the Withings OAuth 2.0 authorization flow:
+
+1. Reads `WITHINGS_CLIENT_ID` / `WITHINGS_CLIENT_SECRET` /
+   `WITHINGS_REDIRECT_URI` from `.env`.
+2. Builds an authorization URL with the `user.metrics` scope (weight
+   readings) and prints it.
+3. You open the URL in your browser, log into Withings, click *Allow
+   access*. Withings redirects to the redirect URI with a `?code=...`
+   query parameter (the redirect page may not exist; the *code* in the
+   URL bar is what matters).
+4. You paste the code back into the terminal.
+5. The script POSTs the code to Withings' token endpoint, gets back an
+   access + refresh token, and stores them in the `withings_auth` table
+   for the given Telegram user_id.
+
+Run: `python setup_withings.py --user <telegram_user_id>`. Required env
+vars must be set first.
+
+### `withings_sync.py` — hourly polling
+
+Run by cron. For every user in `withings_auth`:
+
+1. **`ensure_fresh_token(user_id)`** — if the access token expires within
+   ~10 minutes, refresh via `refresh_access_token`. Withings' refresh
+   sometimes rotates the refresh token too; we store whichever comes
+   back. Token expiry timestamps are ISO UTC.
+2. **`fetch_recent_weights(user_id, days=2)`** — POST to
+   `https://wbsapi.withings.net/measure` with `action=getmeas`,
+   `meastype=1` (weight), and a window covering the last `days` days.
+   Withings encodes measurements as `(value, unit)` where the real number
+   is `value × 10^unit` (e.g. `(67230, -3)` = `67.230 kg`). The decoder
+   handles that. Returns a list of `{measured_at, weight_kg}` dicts.
+3. **`db.insert_weight_reading()`** for each. The `UNIQUE(user_id,
+   measured_at)` constraint silently dedups the overlap with the previous
+   hour's fetch.
+
+CLI:
+- `python withings_sync.py` — sync all connected users.
+- `python withings_sync.py --user <id>` — sync one user.
+- `python withings_sync.py --days N` — fetch the last N days (default 2).
+
+Errors are logged to `withings.log` (gitignored). Anything that returns
+non-zero `status` from Withings (bad token, rate limit, etc.) is logged
+and the script moves on to the next user — no user gets stuck.
+
 ## 12. Cron triggers and proactive pushes
 
 All times are **Berlin wall-clock**. The server's OS timezone is set to
@@ -1354,6 +1445,7 @@ the OS timezone is the actual source of truth).
 | `0 21 * * *` (every day 21:00) | `telegram_bot.py --evening-summary` | `run_evening_summary` → push `advisor.evening_summary` to every user (totals → AI analysis → meal-by-meal). |
 | `0 9 * * 0` (Sunday 09:00) | `telegram_bot.py --weekly-review` | `run_weekly_review` → push `advisor.weekly_review` (3-paragraph Sonnet review covering up to 30 days). |
 | `5 10 * * 6` (Saturday 10:05) | `telegram_bot.py --lint-cron` | `run_lint_cron` → for every user: lint the wiki, detect new contradictions, DM the oldest open one if any. Then global `purge_conversation_older_than(14)`. |
+| `7 * * * *` (every hour at :07) | `withings_sync.py` | For each user in `withings_auth`: refresh access token if needed, pull last 2 days of weight readings from Withings, insert any new ones into `weight_readings`. `daily_stats.weight_kg` is automatically refreshed to the day's min. |
 
 Inside the bot process, two more triggers run reactively rather than on
 a schedule:
@@ -1409,6 +1501,8 @@ both are restarted by `deploy.sh` when present.
 | `OPENAI_API_KEY` | Optional. Only used for Whisper voice transcription in `handle_voice`. Without it, voice messages return an error message. |
 | `NUTRITION_DB_PATH` | Optional override of the SQLite file path (defaults to `./nutrition.db`). Used by the test instance to keep its data separate. |
 | `WIKI_DIR` | Optional override of the wiki base directory (defaults to `./wiki`). |
+| `WITHINGS_CLIENT_ID` / `WITHINGS_CLIENT_SECRET` | Optional. From your Withings developer app at developer.withings.com. Required for the weight-sync integration; without them the hourly `withings_sync.py` cron is a no-op. |
+| `WITHINGS_REDIRECT_URI` | Optional. The callback URL registered with your Withings app. Defaults to `http://localhost:8765/callback`. Used during the one-time `setup_withings.py` bootstrap; never called by the bot at runtime. |
 
 ### crontab snippet
 

--- a/README.md
+++ b/README.md
@@ -163,7 +163,52 @@ Add:
 # (One day before the weekly review so the wiki is clean and any flagged
 # conflicts are surfaced to the user before Sunday's recap lands.)
 5 10 * * 6 /opt/nutrition-bot/venv/bin/python /opt/nutrition-bot/telegram_bot.py --lint-cron >> /opt/nutrition-bot/cron.log 2>&1
+
+# Withings weight sync — every hour at :07
+# Pulls new weight readings from the Withings Health API for every user
+# in the withings_auth table. No-op if no user has connected their account.
+7 * * * * cd /opt/nutrition-bot && /opt/nutrition-bot/venv/bin/python withings_sync.py >> /opt/nutrition-bot/withings.log 2>&1
 ```
+
+## Withings integration (optional — for automated weight sync)
+
+If you have a Withings smart scale, the bot can pull weight readings
+automatically from the Withings Health API. After a one-time setup, the
+hourly cron job above keeps it in sync without any further action from you.
+
+### 1. Register a Withings developer app
+
+Go to [developer.withings.com](https://developer.withings.com/) and create
+a Public API application. You'll get a **CLIENT_ID** and **CONSUMER_SECRET**.
+For the **Callback URL**, use any URL you control or `http://localhost:8765/callback`
+— it just needs to match what's in `.env`.
+
+### 2. Add the credentials to `.env`
+
+```bash
+WITHINGS_CLIENT_ID=...
+WITHINGS_CLIENT_SECRET=...
+WITHINGS_REDIRECT_URI=http://localhost:8765/callback
+```
+
+### 3. Run the one-time authorization
+
+```bash
+python setup_withings.py --user <your_telegram_user_id>
+```
+
+The script prints a URL — open it, log in to Withings, click **Allow access**.
+Your browser will be redirected to the callback URL (the page may not exist,
+that's fine). Copy the `code=...` value from the URL bar back into the
+terminal. Done — the tokens are saved.
+
+### 4. (Optional) Trigger an immediate sync
+
+```bash
+python withings_sync.py --user <your_telegram_user_id>
+```
+
+After that, the hourly cron takes over.
 
 ## Commands
 

--- a/database.py
+++ b/database.py
@@ -142,6 +142,47 @@ def init_db():
 
             CREATE INDEX IF NOT EXISTS idx_convmsg_user_ts
                 ON conversation_messages (user_id, ts);
+
+            -- ─────────────────────────────────────────────
+            -- Raw weight readings (every weighing, not just one per day)
+            --
+            -- Each row is one reading from a scale — typically multiple
+            -- per day. `daily_stats.weight_kg` is automatically updated
+            -- to the MINIMUM reading for that date (the morning-low
+            -- convention), so existing summary code keeps working.
+            --
+            -- UNIQUE(user_id, measured_at) dedups when the polling
+            -- script catches the same Withings reading twice.
+            -- ─────────────────────────────────────────────
+            CREATE TABLE IF NOT EXISTS weight_readings (
+                id              INTEGER PRIMARY KEY AUTOINCREMENT,
+                user_id         INTEGER NOT NULL,
+                measured_at     TEXT    NOT NULL,
+                weight_kg       REAL    NOT NULL,
+                source          TEXT    DEFAULT 'withings_api',
+                inserted_at     TEXT    DEFAULT (datetime('now')),
+                UNIQUE(user_id, measured_at),
+                FOREIGN KEY (user_id) REFERENCES users(user_id)
+            );
+
+            CREATE INDEX IF NOT EXISTS idx_weight_readings_user_date
+                ON weight_readings (user_id, measured_at);
+
+            -- ─────────────────────────────────────────────
+            -- Withings OAuth tokens (one row per user who's connected
+            -- their Withings account). The polling script reads these
+            -- to call the Withings API; the bootstrap setup_withings.py
+            -- writes them after the user authorizes.
+            -- ─────────────────────────────────────────────
+            CREATE TABLE IF NOT EXISTS withings_auth (
+                user_id             INTEGER PRIMARY KEY,
+                access_token        TEXT    NOT NULL,
+                refresh_token       TEXT    NOT NULL,
+                expires_at          TEXT    NOT NULL,
+                withings_user_id    TEXT,
+                updated_at          TEXT    DEFAULT (datetime('now')),
+                FOREIGN KEY (user_id) REFERENCES users(user_id)
+            );
         """)
     # ── Migration: add dish_name to existing databases ───────────────────────
     # ALTER TABLE is a no-op if the column already exists would raise an
@@ -1040,6 +1081,230 @@ def get_latest_weight(user_id: int) -> Optional[float]:
     ).fetchone()
     conn.close()
     return row["weight_kg"] if row else None
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Weight readings (raw history of every weighing)
+#
+# The Withings polling script writes here. `daily_stats.weight_kg` is kept
+# in sync as the MIN reading for each date (the morning-low convention),
+# so all existing summary code continues to see "one weight per day."
+# ─────────────────────────────────────────────────────────────────────────────
+
+def insert_weight_reading(
+    user_id: int,
+    measured_at: str,
+    weight_kg: float,
+    source: str = "withings_api",
+) -> bool:
+    """Insert one raw weight reading. Idempotent via UNIQUE(user_id, measured_at)
+    — re-inserting the same reading (same Withings timestamp) is a silent no-op.
+
+    Also keeps `daily_stats.weight_kg` in sync as the minimum reading for the
+    day this reading falls on (morning-low convention). Returns True if a new
+    row was actually inserted, False if it was a duplicate.
+    """
+    ensure_user(user_id)
+    conn = get_conn()
+    with conn:
+        cur = conn.execute(
+            """INSERT OR IGNORE INTO weight_readings
+                   (user_id, measured_at, weight_kg, source)
+               VALUES (?, ?, ?, ?)""",
+            (user_id, measured_at, float(weight_kg), source),
+        )
+        inserted = cur.rowcount > 0
+    conn.close()
+
+    if inserted:
+        # Update the canonical daily weight to the minimum of all readings
+        # for that calendar day. Done outside the INSERT transaction so the
+        # MIN aggregate sees the row we just wrote.
+        date_str = measured_at[:10]   # ISO YYYY-MM-DD prefix
+        _recompute_daily_weight(user_id, date_str)
+    return inserted
+
+
+def _recompute_daily_weight(user_id: int, date_str: str) -> None:
+    """Set `daily_stats.weight_kg` to the MIN(weight_kg) of all readings on
+    that date (or NULL if none). Called after every weight_readings insert.
+
+    Why min: morning weight is the canonical "true" reading. After breakfast,
+    coffee, water, etc., weight rises during the day. The lowest reading of
+    the day is the cleanest baseline for trend analysis.
+    """
+    conn = get_conn()
+    row = conn.execute(
+        """SELECT MIN(weight_kg) AS min_w FROM weight_readings
+           WHERE user_id = ? AND date(measured_at) = ?""",
+        (user_id, date_str),
+    ).fetchone()
+    min_w = row["min_w"] if row else None
+    if min_w is None:
+        conn.close()
+        return
+
+    # Upsert into daily_stats, only writing weight_kg (other columns
+    # preserved if the row already exists).
+    with conn:
+        existing = conn.execute(
+            "SELECT 1 FROM daily_stats WHERE user_id = ? AND date = ?",
+            (user_id, date_str),
+        ).fetchone()
+        if existing:
+            conn.execute(
+                """UPDATE daily_stats SET weight_kg = ?, updated_at = datetime('now')
+                   WHERE user_id = ? AND date = ?""",
+                (min_w, user_id, date_str),
+            )
+        else:
+            conn.execute(
+                """INSERT INTO daily_stats (user_id, date, weight_kg)
+                   VALUES (?, ?, ?)""",
+                (user_id, date_str, min_w),
+            )
+    conn.close()
+
+
+def get_weight_readings(
+    user_id: int,
+    since: Optional[str] = None,
+    until: Optional[str] = None,
+    limit: Optional[int] = None,
+) -> list[dict]:
+    """Return raw weight readings ordered by measured_at ASC.
+
+    Args:
+        since:  optional lower bound (ISO datetime string).
+        until:  optional upper bound.
+        limit:  optional cap on number of rows.
+    """
+    conn = get_conn()
+    where = ["user_id = ?"]
+    params: list = [user_id]
+    if since:
+        where.append("measured_at >= ?")
+        params.append(since)
+    if until:
+        where.append("measured_at <= ?")
+        params.append(until)
+    sql = (
+        "SELECT * FROM weight_readings WHERE "
+        + " AND ".join(where)
+        + " ORDER BY measured_at"
+    )
+    if limit:
+        sql += " LIMIT ?"
+        params.append(int(limit))
+    rows = conn.execute(sql, params).fetchall()
+    conn.close()
+    return [dict(r) for r in rows]
+
+
+def get_latest_weight_reading(user_id: int) -> Optional[dict]:
+    """Most recent raw reading for this user, or None.
+
+    Different from `get_latest_weight()`, which returns the daily-stats
+    canonical value (the day's min). This returns the most recent INDIVIDUAL
+    weighing — useful when the bot needs to say "you weighed in at 67.3 kg
+    this morning."
+    """
+    conn = get_conn()
+    row = conn.execute(
+        """SELECT * FROM weight_readings
+           WHERE user_id = ?
+           ORDER BY measured_at DESC LIMIT 1""",
+        (user_id,),
+    ).fetchone()
+    conn.close()
+    return dict(row) if row else None
+
+
+def get_daily_min_weights(
+    user_id: int,
+    since: Optional[str] = None,
+) -> list[dict]:
+    """Per-date MIN(weight_kg) from raw readings, oldest first.
+
+    Returns rows shaped {date: 'YYYY-MM-DD', weight_kg: float}. Used by
+    summaries for trend analysis (the canonical "weight per day" series).
+
+    Args:
+        since:  optional lower bound — date or ISO datetime. If None,
+                returns all days that have any reading.
+    """
+    conn = get_conn()
+    where = ["user_id = ?"]
+    params: list = [user_id]
+    if since:
+        where.append("date(measured_at) >= date(?)")
+        params.append(since)
+    sql = (
+        "SELECT date(measured_at) AS date, MIN(weight_kg) AS weight_kg "
+        "FROM weight_readings WHERE "
+        + " AND ".join(where)
+        + " GROUP BY date(measured_at) ORDER BY date"
+    )
+    rows = conn.execute(sql, params).fetchall()
+    conn.close()
+    return [dict(r) for r in rows]
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Withings OAuth tokens
+#
+# The bootstrap setup_withings.py writes here once per user. The polling
+# script reads, calls Withings' API, refreshes tokens as needed.
+# ─────────────────────────────────────────────────────────────────────────────
+
+def get_withings_auth(user_id: int) -> Optional[dict]:
+    """Return this user's Withings OAuth row as a dict, or None if not connected."""
+    conn = get_conn()
+    row = conn.execute(
+        "SELECT * FROM withings_auth WHERE user_id = ?", (user_id,)
+    ).fetchone()
+    conn.close()
+    return dict(row) if row else None
+
+
+def save_withings_auth(
+    user_id: int,
+    access_token: str,
+    refresh_token: str,
+    expires_at: str,
+    withings_user_id: Optional[str] = None,
+) -> None:
+    """Upsert Withings OAuth tokens for this user.
+
+    Called once during initial setup; called again whenever the polling
+    script refreshes the access_token (refresh_token may also rotate).
+    """
+    ensure_user(user_id)
+    conn = get_conn()
+    with conn:
+        conn.execute(
+            """INSERT INTO withings_auth
+                 (user_id, access_token, refresh_token, expires_at,
+                  withings_user_id, updated_at)
+               VALUES (?, ?, ?, ?, ?, datetime('now'))
+               ON CONFLICT(user_id) DO UPDATE SET
+                 access_token     = excluded.access_token,
+                 refresh_token    = excluded.refresh_token,
+                 expires_at       = excluded.expires_at,
+                 withings_user_id = COALESCE(excluded.withings_user_id, withings_user_id),
+                 updated_at       = datetime('now')""",
+            (user_id, access_token, refresh_token, expires_at, withings_user_id),
+        )
+    conn.close()
+
+
+def list_withings_users() -> list[int]:
+    """Return user_ids that have stored Withings OAuth tokens.
+    Used by the polling script to iterate all connected users."""
+    conn = get_conn()
+    rows = conn.execute("SELECT user_id FROM withings_auth").fetchall()
+    conn.close()
+    return [r["user_id"] for r in rows]
 
 
 def get_profile_for_prompt(user_id: int) -> str:

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,6 @@ anthropic>=0.40.0
 openai>=1.0
 python-telegram-bot>=21.0
 python-dotenv>=1.0
+# httpx is already a transitive dep of anthropic; listed explicitly because
+# withings_sync.py imports it directly.
+httpx>=0.27

--- a/setup_withings.py
+++ b/setup_withings.py
@@ -1,0 +1,183 @@
+"""
+setup_withings.py — One-time Withings OAuth bootstrap.
+
+Run this once per user to connect their Withings account to the bot. After
+this script writes the access + refresh tokens to the database, the hourly
+`withings_sync.py` cron job takes over and pulls weight readings forever
+without further user involvement.
+
+Prerequisites — see README's Withings setup section:
+  1. Register a developer app at https://developer.withings.com/
+       Application type: "Withings (public API)"
+       Callback URL: any URL you control or http://localhost:8765/callback
+  2. Copy CLIENT_ID and CONSUMER_SECRET into .env as
+       WITHINGS_CLIENT_ID=...
+       WITHINGS_CLIENT_SECRET=...
+       WITHINGS_REDIRECT_URI=...    (same URL you registered above)
+
+Usage:
+    python setup_withings.py --user 123456789
+
+What it does:
+  1. Builds the Withings authorization URL with your client_id and the
+     requested scope (user.metrics for weight).
+  2. Prints the URL — open it in a browser, log in to Withings, click
+     "Allow".
+  3. Withings redirects to your callback URL with `?code=XYZ` in the query
+     string. Copy that code from your browser's address bar.
+  4. Paste the code back into the terminal.
+  5. The script exchanges the code for access + refresh tokens and stores
+     them in the `withings_auth` table for the given Telegram user_id.
+  6. Done. The hourly cron job picks up from here.
+"""
+
+import argparse
+import os
+import sys
+import urllib.parse
+from datetime import datetime, timedelta, timezone
+
+import httpx
+from dotenv import load_dotenv
+
+import database as db
+
+load_dotenv()
+
+WITHINGS_CLIENT_ID = os.getenv("WITHINGS_CLIENT_ID", "").strip()
+WITHINGS_CLIENT_SECRET = os.getenv("WITHINGS_CLIENT_SECRET", "").strip()
+WITHINGS_REDIRECT_URI = os.getenv(
+    "WITHINGS_REDIRECT_URI", "http://localhost:8765/callback"
+).strip()
+
+WITHINGS_AUTH_URL = "https://account.withings.com/oauth2_user/authorize2"
+WITHINGS_TOKEN_URL = "https://wbsapi.withings.net/v2/oauth2"
+
+# Minimum scope for weight readings. See Withings API docs.
+WITHINGS_SCOPE = "user.metrics"
+
+
+def _build_auth_url(state: str) -> str:
+    params = {
+        "response_type": "code",
+        "client_id": WITHINGS_CLIENT_ID,
+        "scope": WITHINGS_SCOPE,
+        "redirect_uri": WITHINGS_REDIRECT_URI,
+        "state": state,
+    }
+    return f"{WITHINGS_AUTH_URL}?{urllib.parse.urlencode(params)}"
+
+
+def _exchange_code(code: str) -> dict:
+    """Exchange an authorization code for access + refresh tokens.
+    Returns the `body` dict from Withings on success, or raises."""
+    payload = {
+        "action": "requesttoken",
+        "client_id": WITHINGS_CLIENT_ID,
+        "client_secret": WITHINGS_CLIENT_SECRET,
+        "grant_type": "authorization_code",
+        "code": code,
+        "redirect_uri": WITHINGS_REDIRECT_URI,
+    }
+    with httpx.Client(timeout=30.0) as client:
+        resp = client.post(WITHINGS_TOKEN_URL, data=payload)
+    resp.raise_for_status()
+    body = resp.json()
+    if body.get("status") != 0:
+        raise RuntimeError(
+            f"Withings rejected the code: status={body.get('status')} body={body}"
+        )
+    return body.get("body", {})
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Withings OAuth bootstrap")
+    parser.add_argument(
+        "--user", type=int, required=True,
+        help="Telegram user_id to connect (e.g. your own).",
+    )
+    args = parser.parse_args()
+
+    missing = [
+        name for name, value in [
+            ("WITHINGS_CLIENT_ID", WITHINGS_CLIENT_ID),
+            ("WITHINGS_CLIENT_SECRET", WITHINGS_CLIENT_SECRET),
+        ] if not value
+    ]
+    if missing:
+        print(
+            f"❌ Missing env vars: {', '.join(missing)}\n"
+            f"   Add them to .env (see setup_withings.py docstring at the top "
+            f"of this file).",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    db.init_db()
+    db.ensure_user(args.user)
+
+    state = f"bot-user-{args.user}"
+    auth_url = _build_auth_url(state)
+
+    print()
+    print("═" * 76)
+    print("  Step 1 — Open this URL in your browser:")
+    print()
+    print(f"  {auth_url}")
+    print()
+    print("  Step 2 — Log into Withings and click 'Allow access'.")
+    print()
+    print("  Step 3 — Withings will redirect your browser to:")
+    print(f"    {WITHINGS_REDIRECT_URI}?code=XXXXXXXX&state={state}")
+    print()
+    print("  (The page may show 'site can't be reached' — that's fine. The")
+    print("  important thing is the `code=` value in the URL bar.)")
+    print()
+    print("  Step 4 — Copy the value of `code=` (just the code, not the whole URL)")
+    print("  and paste it below.")
+    print("═" * 76)
+    print()
+
+    code = input("Paste the code here: ").strip()
+    if not code:
+        print("❌ No code provided. Aborting.", file=sys.stderr)
+        sys.exit(1)
+
+    try:
+        body = _exchange_code(code)
+    except Exception as e:
+        print(f"❌ Token exchange failed: {e}", file=sys.stderr)
+        sys.exit(1)
+
+    access = body.get("access_token")
+    refresh = body.get("refresh_token")
+    expires_in = int(body.get("expires_in", 10800))
+    expires_at = (datetime.now(timezone.utc) + timedelta(seconds=expires_in)).strftime(
+        "%Y-%m-%dT%H:%M:%SZ"
+    )
+    withings_uid = str(body.get("userid") or "")
+
+    if not access or not refresh:
+        print(f"❌ Withings response missing tokens: {body}", file=sys.stderr)
+        sys.exit(1)
+
+    db.save_withings_auth(
+        user_id=args.user,
+        access_token=access,
+        refresh_token=refresh,
+        expires_at=expires_at,
+        withings_user_id=withings_uid or None,
+    )
+
+    print()
+    print(f"✅ Connected. Stored tokens for Telegram user_id={args.user}")
+    print(f"   Withings user_id: {withings_uid or '(not returned)'}")
+    print(f"   Access token expires at: {expires_at}")
+    print()
+    print("The hourly withings_sync.py cron job will start pulling weight")
+    print("readings on its next tick. To test immediately, run:")
+    print(f"   python withings_sync.py --user {args.user}")
+
+
+if __name__ == "__main__":
+    main()

--- a/wiki.py
+++ b/wiki.py
@@ -16,6 +16,7 @@ import os
 import re
 from datetime import datetime
 from pathlib import Path
+from typing import Optional
 
 # ─────────────────────────────────────────────────────────────────────────────
 # Paths
@@ -305,6 +306,123 @@ def set_daily_kcal(user_id: int, kcal: int) -> None:
     canonical = _CALORIE_GOAL_CANONICAL.format(kcal=int(kcal))
     new_content = _rewrite_goals_with_canonical(content, canonical)
     write_page(user_id, "goals", new_content)
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Target weight — read/write helpers backed by goals.md
+#
+# Parallel to the calorie-goal plumbing above. One canonical line in goals.md:
+#   - **Target weight**: 62 kg
+# The Withings sync layer doesn't touch this — it's purely a user preference
+# the bot uses to add goal-progress framing to summaries ("1.8 kg away").
+# ─────────────────────────────────────────────────────────────────────────────
+
+_TARGET_WEIGHT_CANONICAL = "- **Target weight**: {kg} kg"
+
+# Lenient reader for legacy phrasings ("Goal weight: 62kg", "target 60 kilos",
+# "weight goal 62kg"). Requires `kg` unit so we never collide with the
+# `kcal` calorie line or generic "goal 100g protein" style bullets.
+_TARGET_WEIGHT_RE = re.compile(
+    r"^[ \t]*[-*+][ \t]+"                              # bullet marker
+    r"(?:\[\d{4}-\d{2}-\d{2}\][ \t]+)?"                # optional date prefix
+    r"(?:\*\*)?"                                        # optional open bold
+    r"(?:target|goal)[ \t]+(?:body[ \t]+)?weight"     # label
+    r"(?:\*\*)?"                                        # optional close bold
+    r"[ \t]*[:—–\-]?[ \t]*"                            # optional separator
+    r"(\d+(?:\.\d+)?)"                                  # the number (allow .5)
+    r"[ \t]*(?:kg|kilos?|kilograms?)\b"                # unit MUST be kg
+    r".*$",                                             # rest of line
+    re.IGNORECASE | re.MULTILINE,
+)
+
+
+def get_target_weight(user_id: int, default: Optional[float] = None) -> Optional[float]:
+    """Read the target weight from goals.md. Returns `default` (None by default)
+    if the line is missing or malformed. Never crashes on hand-edits or
+    Haiku drift."""
+    content = read_page(user_id, "goals")
+    if not content:
+        return default
+    m = _TARGET_WEIGHT_RE.search(content)
+    if not m:
+        return default
+    try:
+        return float(m.group(1))
+    except (ValueError, AttributeError):
+        return default
+
+
+def set_target_weight(user_id: int, weight_kg: float) -> None:
+    """Upsert the canonical target-weight bullet in goals.md.
+
+    Strips every existing target-weight-ish line (canonical form, legacy
+    phrasings, Haiku-ingested prose) and inserts exactly one canonical
+    bullet right under the `# Goals` heading. All non-target-weight bullets
+    (calorie goal, sugar, protein, etc.) are preserved byte-for-byte since
+    this regex is scoped to the `kg` unit.
+
+    Caller is responsible for holding `get_lock(user_id)`.
+    """
+    ensure_user_wiki(user_id)
+    content = read_page(user_id, "goals")
+    # Format whole numbers without a trailing ".0" for tidy display.
+    kg = int(weight_kg) if weight_kg == int(weight_kg) else round(weight_kg, 1)
+    canonical = _TARGET_WEIGHT_CANONICAL.format(kg=kg)
+    new_content = _rewrite_goals_with_target_canonical(content, canonical)
+    write_page(user_id, "goals", new_content)
+
+
+def _rewrite_goals_with_target_canonical(content: str, canonical: str) -> str:
+    """Mirror of `_rewrite_goals_with_canonical` but scoped to the
+    target-weight regex. Strips matching lines, removes the empty
+    placeholder, collapses blank-line runs, inserts the canonical bullet
+    right under `# Goals` (or builds the heading if it didn't exist).
+    """
+    stripped = _TARGET_WEIGHT_RE.sub("", content)
+    stripped = strip_empty_placeholder(stripped)
+    stripped = re.sub(r"\n{3,}", "\n\n", stripped)
+
+    heading_re = re.compile(r"^#[ \t]+goals[ \t]*$", re.IGNORECASE | re.MULTILINE)
+    m = heading_re.search(stripped)
+    if m:
+        insert_at = m.end()
+        new_content = stripped[:insert_at] + "\n\n" + canonical + stripped[insert_at:]
+    else:
+        new_content = f"# Goals\n\n{canonical}\n\n{stripped.lstrip()}"
+
+    return re.sub(r"\n{3,}", "\n\n", new_content).rstrip() + "\n"
+
+
+def consolidate_target_weight_line(user_id: int) -> dict:
+    """Lint-time consolidation of any target-weight drift, mirroring
+    `consolidate_goal_line` for kcal. Keep the LAST number (later wins).
+    Returns {"found": N, "kept": float|None, "rewrote": bool}.
+
+    Caller holds `get_lock(user_id)`.
+    """
+    ensure_user_wiki(user_id)
+    content = read_page(user_id, "goals")
+    if not content:
+        return {"found": 0, "kept": None, "rewrote": False}
+
+    matches = list(_TARGET_WEIGHT_RE.finditer(content))
+    if not matches:
+        return {"found": 0, "kept": None, "rewrote": False}
+
+    try:
+        kept_value = float(matches[-1].group(1))
+    except (ValueError, AttributeError):
+        return {"found": len(matches), "kept": None, "rewrote": False}
+
+    kg = int(kept_value) if kept_value == int(kept_value) else round(kept_value, 1)
+    canonical = _TARGET_WEIGHT_CANONICAL.format(kg=kg)
+
+    rebuilt = _rewrite_goals_with_target_canonical(content, canonical)
+    if rebuilt == content:
+        return {"found": len(matches), "kept": kept_value, "rewrote": False}
+
+    write_page(user_id, "goals", rebuilt)
+    return {"found": len(matches), "kept": kept_value, "rewrote": True}
 
 
 # ─────────────────────────────────────────────────────────────────────────────

--- a/withings_sync.py
+++ b/withings_sync.py
@@ -1,0 +1,301 @@
+"""
+withings_sync.py — Pull weight readings from the Withings Health API.
+
+Runs hourly via cron. For each user who has connected their Withings account
+(via setup_withings.py), this script:
+
+  1. Refreshes the access_token if it's about to expire (or has expired).
+  2. Calls Withings' measure?action=getmeas endpoint to fetch new weight
+     readings since the last successful sync.
+  3. Inserts new readings into the `weight_readings` table.
+     UNIQUE(user_id, measured_at) makes this idempotent — re-fetching the
+     same window is safe.
+  4. `database.insert_weight_reading` automatically updates
+     `daily_stats.weight_kg` to the day's MIN reading, so existing summary
+     code continues to see "one weight per day."
+
+Withings API docs: https://developer.withings.com/api-reference
+
+Run:
+    python withings_sync.py                # sync all connected users
+    python withings_sync.py --user 12345   # sync one user
+    python withings_sync.py --days 7       # fetch the last 7 days (default 2)
+
+Cron entry (added to /etc/cron.d or root's crontab):
+    # Withings weight sync — every hour at :07
+    7 * * * * cd /opt/nutrition-bot && /opt/nutrition-bot/venv/bin/python withings_sync.py >> /opt/nutrition-bot/withings.log 2>&1
+"""
+
+import argparse
+import logging
+import os
+import sys
+import time
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Optional
+
+import httpx
+from dotenv import load_dotenv
+
+import database as db
+
+load_dotenv()
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Config
+# ─────────────────────────────────────────────────────────────────────────────
+
+WITHINGS_CLIENT_ID = os.getenv("WITHINGS_CLIENT_ID", "")
+WITHINGS_CLIENT_SECRET = os.getenv("WITHINGS_CLIENT_SECRET", "")
+
+# Withings API endpoints (stable, documented).
+WITHINGS_TOKEN_URL = "https://wbsapi.withings.net/v2/oauth2"
+WITHINGS_MEASURE_URL = "https://wbsapi.withings.net/measure"
+
+# Withings measurement type code for weight (kg). See:
+# https://developer.withings.com/api-reference/#section/Withings-Data-API/Measurement-Types
+WITHINGS_TYPE_WEIGHT = 1
+
+# Refresh the access token if it expires within this many seconds. Withings
+# access tokens last 3 hours; we refresh proactively to avoid a race with
+# the API call that follows.
+TOKEN_REFRESH_LEEWAY_S = 600   # 10 min
+
+# Dedicated log file so it's easy to tail. Separate from the main bot log.
+_log_path = Path(__file__).parent / "withings.log"
+logging.basicConfig(
+    filename=_log_path,
+    level=logging.INFO,
+    format="%(asctime)s [%(levelname)s] %(message)s",
+)
+# Also echo to stdout when run interactively (cron captures stdout via >>).
+_console = logging.StreamHandler(sys.stdout)
+_console.setFormatter(logging.Formatter("%(asctime)s [%(levelname)s] %(message)s"))
+logging.getLogger().addHandler(_console)
+log = logging.getLogger("withings_sync")
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# OAuth token refresh
+# ─────────────────────────────────────────────────────────────────────────────
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def _parse_iso(s: str) -> datetime:
+    """Tolerant ISO parser — accepts 'Z' suffix and '+00:00' both."""
+    if s.endswith("Z"):
+        s = s[:-1] + "+00:00"
+    return datetime.fromisoformat(s)
+
+
+def refresh_access_token(user_id: int) -> Optional[dict]:
+    """Use the stored refresh_token to fetch a new access_token. Writes the
+    new tokens back to the DB and returns the updated row dict (or None on
+    failure).
+    """
+    auth = db.get_withings_auth(user_id)
+    if not auth:
+        log.warning(f"user={user_id} refresh: no withings_auth row")
+        return None
+
+    payload = {
+        "action": "requesttoken",
+        "client_id": WITHINGS_CLIENT_ID,
+        "client_secret": WITHINGS_CLIENT_SECRET,
+        "grant_type": "refresh_token",
+        "refresh_token": auth["refresh_token"],
+    }
+
+    try:
+        with httpx.Client(timeout=30.0) as client:
+            resp = client.post(WITHINGS_TOKEN_URL, data=payload)
+        resp.raise_for_status()
+        body = resp.json()
+    except Exception as e:
+        log.error(f"user={user_id} refresh: HTTP failed: {e!r}")
+        return None
+
+    # Withings wraps everything in {"status": int, "body": {...}}. status=0 OK.
+    if body.get("status") != 0:
+        log.error(f"user={user_id} refresh: API status={body.get('status')} body={body}")
+        return None
+
+    data = body.get("body", {})
+    new_access = data.get("access_token")
+    new_refresh = data.get("refresh_token", auth["refresh_token"])
+    expires_in = int(data.get("expires_in", 10800))
+    expires_at = (datetime.now(timezone.utc) + timedelta(seconds=expires_in)).strftime(
+        "%Y-%m-%dT%H:%M:%SZ"
+    )
+    withings_uid = str(data.get("userid") or auth.get("withings_user_id") or "")
+
+    if not new_access:
+        log.error(f"user={user_id} refresh: no access_token in response: {data}")
+        return None
+
+    db.save_withings_auth(
+        user_id=user_id,
+        access_token=new_access,
+        refresh_token=new_refresh,
+        expires_at=expires_at,
+        withings_user_id=withings_uid or None,
+    )
+    log.info(f"user={user_id} refresh OK; new expiry={expires_at}")
+    return db.get_withings_auth(user_id)
+
+
+def ensure_fresh_token(user_id: int) -> Optional[dict]:
+    """Return the user's withings_auth row, refreshing the access_token first
+    if it's expired or about to expire (within TOKEN_REFRESH_LEEWAY_S)."""
+    auth = db.get_withings_auth(user_id)
+    if not auth:
+        return None
+
+    try:
+        expires_at = _parse_iso(auth["expires_at"])
+    except (ValueError, KeyError):
+        # Malformed timestamp — force a refresh.
+        return refresh_access_token(user_id)
+
+    leeway = timedelta(seconds=TOKEN_REFRESH_LEEWAY_S)
+    if datetime.now(timezone.utc) + leeway >= expires_at:
+        return refresh_access_token(user_id)
+    return auth
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Measurement fetch
+# ─────────────────────────────────────────────────────────────────────────────
+
+def _decode_weight(value: int, unit: int) -> float:
+    """Withings encodes measurements as (value, unit) where the real number
+    is value * 10^unit. E.g. (67230, -3) = 67.230 kg."""
+    return value * (10 ** unit)
+
+
+def fetch_recent_weights(
+    user_id: int,
+    days: int = 2,
+) -> Optional[list[dict]]:
+    """Call Withings measure?action=getmeas for the last `days` days.
+    Returns a list of {measured_at: ISO, weight_kg: float} dicts, or None
+    on transport/API failure.
+
+    Idempotent re-fetching: the DB insert dedups on (user_id, measured_at)
+    so calling this repeatedly with overlapping windows is fine.
+    """
+    auth = ensure_fresh_token(user_id)
+    if not auth:
+        return None
+
+    end_ts = int(time.time())
+    start_ts = end_ts - days * 86400
+
+    payload = {
+        "action": "getmeas",
+        "meastype": str(WITHINGS_TYPE_WEIGHT),
+        "category": "1",          # 1 = real measurements (not user-entered targets)
+        "startdate": str(start_ts),
+        "enddate": str(end_ts),
+    }
+    headers = {"Authorization": f"Bearer {auth['access_token']}"}
+
+    try:
+        with httpx.Client(timeout=30.0) as client:
+            resp = client.post(WITHINGS_MEASURE_URL, data=payload, headers=headers)
+        resp.raise_for_status()
+        body = resp.json()
+    except Exception as e:
+        log.error(f"user={user_id} getmeas: HTTP failed: {e!r}")
+        return None
+
+    if body.get("status") != 0:
+        log.error(f"user={user_id} getmeas: API status={body.get('status')} body={body}")
+        # Status 401/283 = bad token: force a refresh on the next run by
+        # bumping expiry. Done deliberately small so we try again hourly.
+        return None
+
+    readings: list[dict] = []
+    for grp in body.get("body", {}).get("measuregrps", []) or []:
+        ts = int(grp.get("date", 0))
+        for m in grp.get("measures", []) or []:
+            if m.get("type") != WITHINGS_TYPE_WEIGHT:
+                continue
+            try:
+                kg = _decode_weight(int(m["value"]), int(m["unit"]))
+            except (KeyError, ValueError):
+                continue
+            iso = datetime.fromtimestamp(ts, tz=timezone.utc).strftime(
+                "%Y-%m-%dT%H:%M:%SZ"
+            )
+            readings.append({"measured_at": iso, "weight_kg": float(kg)})
+    return readings
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Per-user sync
+# ─────────────────────────────────────────────────────────────────────────────
+
+def sync_user(user_id: int, days: int = 2) -> dict:
+    """Refresh tokens if needed, fetch last `days` of readings, insert any
+    new ones. Returns a small stats dict for logging."""
+    readings = fetch_recent_weights(user_id, days=days)
+    if readings is None:
+        return {"user_id": user_id, "ok": False, "fetched": 0, "inserted": 0}
+
+    inserted = 0
+    for r in readings:
+        if db.insert_weight_reading(
+            user_id=user_id,
+            measured_at=r["measured_at"],
+            weight_kg=r["weight_kg"],
+            source="withings_api",
+        ):
+            inserted += 1
+
+    log.info(
+        f"user={user_id} sync OK fetched={len(readings)} new={inserted}"
+    )
+    return {"user_id": user_id, "ok": True, "fetched": len(readings), "inserted": inserted}
+
+
+def sync_all_users(days: int = 2) -> list[dict]:
+    """Iterate every user who has stored Withings tokens."""
+    user_ids = db.list_withings_users()
+    log.info(f"sync_all_users start; {len(user_ids)} user(s) connected")
+    return [sync_user(uid, days=days) for uid in user_ids]
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# CLI
+# ─────────────────────────────────────────────────────────────────────────────
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Withings weight sync")
+    parser.add_argument("--user", type=int, default=None,
+                        help="Sync only this Telegram user_id")
+    parser.add_argument("--days", type=int, default=2,
+                        help="How many days of history to fetch (default 2)")
+    args = parser.parse_args()
+
+    if not WITHINGS_CLIENT_ID or not WITHINGS_CLIENT_SECRET:
+        log.error("WITHINGS_CLIENT_ID / WITHINGS_CLIENT_SECRET missing from .env")
+        sys.exit(1)
+
+    db.init_db()
+
+    if args.user:
+        result = sync_user(args.user, days=args.days)
+        log.info(f"done: {result}")
+    else:
+        results = sync_all_users(days=args.days)
+        ok = sum(1 for r in results if r["ok"])
+        inserted = sum(r["inserted"] for r in results)
+        log.info(f"done: {ok}/{len(results)} users OK; {inserted} new readings")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
First half of issue #7. After this lands, weight readings flow automatically from Withings into the DB every hour. Nothing user-visible changes yet — that's PR B's job (summary updates + proactive observations).

What this PR adds:

Schema (database.py init_db):
  - weight_readings table — raw history of every weighing, one row per reading. UNIQUE(user_id, measured_at) dedups when the polling script overlaps with a previous fetch. Plus index on (user_id, measured_at).
  - withings_auth table — per-user OAuth tokens (access, refresh, expiry, Withings' own user id). One row per connected user.

Database helpers:
  - insert_weight_reading(user_id, measured_at, weight_kg, source) — returns True on a fresh insert, False on dedup. Automatically updates daily_stats.weight_kg to the day's MIN reading (morning-low convention) so existing summary code keeps working unchanged.
  - _recompute_daily_weight(user_id, date_str) — internal helper that runs after each insert.
  - get_weight_readings(user_id, since, until, limit) — raw history.
  - get_latest_weight_reading(user_id) — most recent INDIVIDUAL weighing (different from get_latest_weight which returns the canonical daily value).
  - get_daily_min_weights(user_id, since) — per-date MIN series for trend analysis.
  - get_withings_auth / save_withings_auth / list_withings_users — OAuth token CRUD.

Wiki helpers (wiki.py):
  - Target weight canonical line in goals.md, parallel to the kcal goal:  - **Target weight**: 62 kg
  - get_target_weight(user_id, default=None) → Optional[float]
  - set_target_weight(user_id, weight_kg) — upserts the canonical line, preserves all non-target-weight bullets byte-for-byte (scoped to `kg` unit so it never collides with the kcal goal or generic "100g protein" style bullets).
  - consolidate_target_weight_line(user_id) — for lint, mirrors consolidate_goal_line.

New scripts:
  - withings_sync.py — hourly polling. For each user in withings_auth: refresh access token if needed, fetch last 2 days of weight readings from Withings (decoded from their (value, unit) format), insert any new ones. CLI: --user N, --days N. Errors logged to withings.log (gitignored). Designed to be safe to re-run — the UNIQUE constraint dedups.
  - setup_withings.py — one-time interactive OAuth bootstrap. Prints the auth URL, takes the redirected code, exchanges it for tokens, stores them. Run once per user.

Config:
  - .env.example — three new Withings variables (CLIENT_ID, CLIENT_SECRET, REDIRECT_URI). All optional; the sync cron is a no-op if any are missing.
  - .gitignore — withings.log.
  - requirements.txt — httpx (already transitively present via anthropic SDK; listed explicitly since withings_sync.py imports it directly).

Docs:
  - README — new "Withings integration (optional)" section with the 4-step setup walkthrough. New cron line added to the crontab snippet.
  - ARCHITECTURE.md — weight_readings and withings_auth tables documented under §3.1; new §11A module reference for withings_sync.py + setup_withings.py describing the OAuth flow, the (value, unit) decode trick, and the per-user idempotency behaviour. Cron table in §12 and env-var table in §13 both extended.

Smoke-tested end-to-end with an in-memory DB: insert dedup works, morning-low rule fires correctly (canonical daily weight = MIN of day's readings), target weight + kcal goal coexist in goals.md without clobbering each other.

This is the plumbing half of #7. PR B will add summary surfacing, weight-pattern ingest, and goal-progress framing.