### PR TITLE
PR B — Surface weight readings in summaries + proactive observations

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -998,6 +998,61 @@ by the analyzer.
 map and a renderer for the activity block (weight + steps + per-workout
 lines + total burn).
 
+### 8.3A Weight tracking (issue #7 surfacing)
+
+Reads from the `weight_readings` table populated by `withings_sync.py`
+and the target weight in `goals.md`. All helpers gracefully return
+empty/None on a fresh user with no readings — they're safe to call
+unconditionally.
+
+#### `_weight_context(user_id) → dict`
+
+Computes the user's weight situation from the last ~35 days of
+readings. Returns a dict with `current_kg` (today's morning-low if
+available), `yesterday_kg`, `week_ago_kg`, `month_ago_kg`, their signed
+deltas, `target_kg` (from `goals.md`), `delta_target`,
+`pace_kg_per_wk` (linear end-to-end trend over the window, only if ≥14
+days of data), and `history` (the raw per-date min series).
+
+The "look up the weight at N days ago" uses a ±2-day search window so
+we don't return None just because the user skipped a weighing.
+
+#### `_fmt_arrow_delta(delta, unit="kg") → str`
+
+Renders a signed number with an arrow: `↓ 0.2 kg`, `↑ 0.3 kg`, or
+`steady` for `|delta| < 0.05`.
+
+#### `_fmt_weight_block(user_id, mode="evening"|"weekly") → str`
+
+Renders a formatted weight block for inclusion in summaries. Empty
+string if there's no data.
+
+- `mode="evening"` — compact: current weight, day + week deltas on one
+  line, target distance.
+- `mode="weekly"` — richer: week start→current, month delta, target
+  distance, and a "pace per month + weeks-to-target" projection when
+  the trend is heading toward the target.
+
+#### `_fmt_weight_context_for_prompt(user_id) → str`
+
+Compact text describing the weight situation, suitable for injection
+into a Sonnet system prompt (`answer_question`, `evening_summary`,
+`weekly_review`). Empty string if no data.
+
+#### Surfacing — where each helper is used
+
+- **Evening summary**: `_fmt_weight_block(mode="evening")` is inserted
+  between the totals block and the AI analysis paragraph. The prompt
+  also gets the `_fmt_weight_context_for_prompt` string so the analysis
+  can reference weight when relevant.
+- **Weekly review**: `_fmt_weight_block(mode="weekly")` joins the stats
+  header (after on-track count, past-month avg). The prompt gets the
+  context string so the review's three paragraphs can weave in trend +
+  target progress.
+- **`answer_question`**: the context string is added to the system
+  prompt so Sonnet can answer "how's my weight progress?" type
+  questions concretely.
+
 ### 8.4 Day-level summaries
 
 #### `day_summary(user_id, for_date, label, *, include_totals=True) → str`
@@ -1173,9 +1228,20 @@ and our write. Each page goes through: empty-check, `_lint_page` call,
 sanity check, backup, `write_page`. Results dict is
 `{page: {before, after, rewritten}}` or `{page: {skipped: 'empty'}}`.
 
-After all pages, runs `wiki.consolidate_goal_line` as a deterministic
-safety pass on `goals.md` (collapsing any calorie-goal drift Haiku
-didn't catch).
+After all pages, runs three deterministic post-passes (all wrapped in
+try/except — none can break the lint):
+
+1. `wiki.consolidate_goal_line` — collapses any calorie-goal drift on
+   `goals.md` into the single canonical bullet.
+2. `wiki.consolidate_target_weight_line` — same idea for the target
+   weight line (issue #7).
+3. `_append_weight_observations` (issue #7) — detects clear
+   trends / plateaus / milestones in the user's weight history from
+   `weight_readings` and appends new (non-duplicate) dated bullets to
+   `patterns.md`. Templates only — no LLM call. Thresholds tuned
+   conservatively: trend ≥ 0.2 kg/week for ≥ 3 weeks; plateau =
+   max-min < 0.4 kg over 14 days; milestone = crossed an integer-kg
+   boundary in the past 7 days.
 
 **Called from:** `cmd_lint`, `run_lint_cron`, `_run_post_change_lint`.
 
@@ -1462,10 +1528,11 @@ a schedule:
 
 | User-visible | Internal-only |
 | --- | --- |
-| Evening summary (21:00 daily) | Post-ingest lint runs |
-| Sunday weekly review (Sun 09:00) | Conversation-message purge runs |
+| Evening summary (21:00 daily) — includes weight + target progress block when readings exist | Post-ingest lint runs |
+| Sunday weekly review (Sun 09:00) — weight trend + target progress + pace projection | Conversation-message purge runs |
 | Saturday contradiction DM (Sat 10:05, only when something is open) | Lint backups under `.backups/` |
-| 80%/100% goal alert (in-line with the meal-log reply) | `ingest.log`, `lint.log`, `contradictions.log` breadcrumbs |
+| 80%/100% goal alert (in-line with the meal-log reply) | `ingest.log`, `lint.log`, `contradictions.log`, `withings.log` breadcrumbs |
+| Hourly Withings weight sync (silent — readings just appear in summaries) | Weight-pattern observations get appended to `patterns.md` on Saturday lint |
 
 ---
 

--- a/advisor.py
+++ b/advisor.py
@@ -495,15 +495,6 @@ def weekly_review(user_id: int) -> str:
     avg_prot_month = _avg(month_data, "protein_g")
     days_on_track  = sum(1 for r in this_week if abs(r["kcal"] - goal) / goal < 0.15)
 
-    # Weight trend from activity stats
-    weights = [(s["date"], s["weight_kg"]) for s in week_stats if s.get("weight_kg")]
-    weight_line = ""
-    if weights:
-        w_first, w_last = weights[0][1], weights[-1][1]
-        delta = w_last - w_first
-        arrow = f"↓ {abs(delta):.1f} kg" if delta < 0 else (f"↑ {delta:.1f} kg" if delta > 0 else "stable")
-        weight_line = f"Weight: {w_first:.1f} → {w_last:.1f} kg ({arrow})"
-
     # Stats header (numbers only, no AI)
     header_parts = [
         f"📅 *Sunday Review* ({len(month_data)} days logged)",
@@ -511,8 +502,13 @@ def weekly_review(user_id: int) -> str:
     ]
     if older:
         header_parts.append(f"Past month avg: {avg_kcal_month:.0f} kcal/day — {avg_prot_month:.0f}g protein")
-    if weight_line:
-        header_parts.append(weight_line)
+
+    # Weight block (richer "weekly" mode — start→end, month delta, target progress + pace).
+    # Reads from weight_readings (issue #7); empty string if no readings yet,
+    # in which case we don't add a weight line at all.
+    weight_block = _fmt_weight_block(user_id, mode="weekly")
+    if weight_block:
+        header_parts.append(weight_block)
     header = "\n".join(header_parts)
 
     # Build data summary for Claude
@@ -523,9 +519,12 @@ def weekly_review(user_id: int) -> str:
     )
 
     profile = wiki.read_wiki_for_prompt(user_id)
+    weight_context_for_prompt = _fmt_weight_context_for_prompt(user_id)
+
     prompt = f"""You are a supportive personal nutritionist sending a detailed Sunday weekly review to your client.
 
 User's daily calorie goal: {goal} kcal
+{weight_context_for_prompt}
 {f"What I know about this user (long-term memory):{chr(10)}{profile}" if profile else ""}
 
 Data for the past {len(month_data)} days (all available history):
@@ -533,11 +532,11 @@ Data for the past {len(month_data)} days (all available history):
 
 Write a concise review in exactly 3 short paragraphs, each separated by a blank line. Keep it tight — the user wants signal, not padding.
 
-Paragraph 1 — This week verdict: overall calorie consistency + protein, with specific numbers and a clear verdict. Mention the best and worst day briefly.
+Paragraph 1 — This week verdict: overall calorie consistency + protein, with specific numbers and a clear verdict. Mention the best and worst day briefly. If weight context is available, weave in this week's weight movement.
 
-Paragraph 2 — The main pattern worth noticing: one observation from the longer arc (or this week's highlight if no longer history exists). Combine wins and gaps honestly.
+Paragraph 2 — The main pattern worth noticing: one observation from the longer arc. Combine wins and gaps honestly. If a weight trend is visible (steady, down, up), call it out and connect it to the eating pattern.
 
-Paragraph 3 — One concrete recommendation for the coming week, tied directly to what you just said.
+Paragraph 3 — One concrete recommendation for the coming week, tied directly to what you just said. If a target weight exists, frame the recommendation around progress toward it.
 
 Each paragraph should be 2-3 sentences MAX. Warm, coach-like tone. No bullet points. No headers. Just short paragraphs.
 Use Telegram formatting: *bold* sparingly for key numbers.
@@ -572,10 +571,12 @@ def answer_question(user_id: int, question: str, conversation: list[dict] | None
     week = db.get_week_totals(user_id)
 
     profile = wiki.read_wiki_for_prompt(user_id)
+    weight_context_for_prompt = _fmt_weight_context_for_prompt(user_id)
     context = f"""You are a friendly, knowledgeable personal nutritionist.
 You have access to the user's food tracking data below. Use it when relevant.
 
 User's current daily calorie goal: {goal} kcal
+{weight_context_for_prompt}
 Today's logged meals: {json.dumps(today_meals, default=str)}
 This week's daily totals: {json.dumps(week, default=str)}
 {f"{chr(10)}What I know about this user (long-term memory):{chr(10)}{profile}" if profile else ""}
@@ -729,6 +730,247 @@ def _fmt_activity(stats: dict) -> str:
 
 
 # ─────────────────────────────────────────────────────────────────────────────
+# Weight tracking — analysis + display helpers
+#
+# Reads from the `weight_readings` table populated by withings_sync.py (issue
+# #7 plumbing) and the target weight in goals.md. All helpers gracefully
+# return empty/None when there's no data — they're safe to call on a fresh
+# user who hasn't connected Withings yet.
+# ─────────────────────────────────────────────────────────────────────────────
+
+def _weight_context(user_id: int) -> dict:
+    """Compute weight stats for summaries and Q&A.
+
+    Returns a dict with whatever's computable. All numeric values may be None
+    when there isn't enough data. Shape:
+
+        {
+            "current_kg":     float | None,  # most recent reading
+            "yesterday_kg":   float | None,  # min reading from yesterday
+            "week_ago_kg":    float | None,  # min reading from ~7 days back
+            "month_ago_kg":   float | None,  # min reading from ~30 days back
+            "delta_day":      float | None,  # current - yesterday
+            "delta_week":     float | None,  # current - week_ago
+            "delta_month":    float | None,  # current - month_ago
+            "target_kg":      float | None,  # from goals.md
+            "delta_target":   float | None,  # current - target_kg (signed)
+            "pace_kg_per_wk": float | None,  # average weekly trend over 30 days
+            "history":        list[dict],    # last 30 days of (date, weight_kg)
+        }
+    """
+    out = {
+        "current_kg": None, "yesterday_kg": None,
+        "week_ago_kg": None, "month_ago_kg": None,
+        "delta_day": None, "delta_week": None, "delta_month": None,
+        "target_kg": None, "delta_target": None,
+        "pace_kg_per_wk": None,
+        "history": [],
+    }
+
+    # Per-date min series for trend math. Pulls last 35 days to give headroom
+    # for the "7 days ago" / "30 days ago" lookups.
+    today = date.today()
+    since = (today - timedelta(days=35)).isoformat()
+    history = db.get_daily_min_weights(user_id, since=since)
+    out["history"] = history
+
+    if not history:
+        # No raw readings yet — fall back to most recent individual reading
+        # or legacy daily_stats.weight_kg so we still display SOMETHING.
+        latest = db.get_latest_weight_reading(user_id)
+        out["current_kg"] = (
+            latest["weight_kg"] if latest else db.get_latest_weight(user_id)
+        )
+        target = wiki.get_target_weight(user_id)
+        if target is not None:
+            out["target_kg"] = target
+            if out["current_kg"] is not None:
+                out["delta_target"] = out["current_kg"] - target
+        return out
+
+    by_date = {row["date"]: row["weight_kg"] for row in history}
+
+    # current_kg = today's morning-low if we have a reading today, else the
+    # most recent day's min in the history. We deliberately use the day-min
+    # (not the most-recent individual reading) so it's consistent with the
+    # deltas (also day-mins) and stable across the day.
+    today_str = today.isoformat()
+    if today_str in by_date:
+        out["current_kg"] = by_date[today_str]
+    else:
+        out["current_kg"] = history[-1]["weight_kg"]
+
+    def _lookup_around(target_date: date, window_days: int = 3) -> Optional[float]:
+        """Return the weight nearest to target_date within ±window_days."""
+        for offset in range(window_days + 1):
+            for sign in (0, -1, 1):
+                d = (target_date + timedelta(days=sign * offset)).isoformat()
+                if d in by_date:
+                    return by_date[d]
+        return None
+
+    out["yesterday_kg"] = _lookup_around(today - timedelta(days=1), window_days=1)
+    out["week_ago_kg"]  = _lookup_around(today - timedelta(days=7), window_days=2)
+    out["month_ago_kg"] = _lookup_around(today - timedelta(days=30), window_days=4)
+
+    if out["current_kg"] is not None:
+        if out["yesterday_kg"] is not None:
+            out["delta_day"] = out["current_kg"] - out["yesterday_kg"]
+        if out["week_ago_kg"] is not None:
+            out["delta_week"] = out["current_kg"] - out["week_ago_kg"]
+        if out["month_ago_kg"] is not None:
+            out["delta_month"] = out["current_kg"] - out["month_ago_kg"]
+
+    # Pace: linear weekly trend from the oldest reading in the window to the
+    # current. Simple end-to-end average; doesn't try to be clever about
+    # short-term noise. Only computed if we have at least 14 days of data.
+    if len(history) >= 14:
+        first = history[0]
+        last = history[-1]
+        try:
+            d_start = date.fromisoformat(first["date"])
+            d_end = date.fromisoformat(last["date"])
+            span_days = max(1, (d_end - d_start).days)
+            kg_change = last["weight_kg"] - first["weight_kg"]
+            out["pace_kg_per_wk"] = kg_change / span_days * 7
+        except (ValueError, KeyError):
+            pass
+
+    # Target weight + distance.
+    target = wiki.get_target_weight(user_id)
+    if target is not None:
+        out["target_kg"] = target
+        if out["current_kg"] is not None:
+            out["delta_target"] = out["current_kg"] - target
+
+    return out
+
+
+def _fmt_arrow_delta(delta: float, unit: str = "kg") -> str:
+    """Render a signed delta with an arrow.
+        +0.3 → '↑ 0.3 kg'
+        -0.2 → '↓ 0.2 kg'
+         0.0 → 'steady'
+    """
+    if abs(delta) < 0.05:
+        return "steady"
+    arrow = "↑" if delta > 0 else "↓"
+    return f"{arrow} {abs(delta):.1f} {unit}"
+
+
+def _fmt_weight_block(user_id: int, mode: str = "evening") -> str:
+    """Format a weight block for inclusion in a summary.
+
+    Returns empty string if there's no weight data at all (so the caller
+    can append unconditionally without checking).
+
+    Args:
+        mode: 'evening' for compact 2–3 lines (evening push, /today),
+              'weekly' for a richer block (Sunday review).
+    """
+    ctx = _weight_context(user_id)
+    cur = ctx["current_kg"]
+    if cur is None:
+        return ""
+
+    lines: list[str] = []
+
+    if mode == "weekly":
+        # Header: this-week start → current, plus one-line delta.
+        wk = ctx["week_ago_kg"]
+        if wk is not None:
+            lines.append(f"⚖️ Weight: *{wk:.1f} → {cur:.1f} kg* this week ({_fmt_arrow_delta(cur - wk)})")
+        else:
+            lines.append(f"⚖️ Weight: *{cur:.1f} kg*")
+
+        if ctx["delta_month"] is not None:
+            lines.append(f"   {_fmt_arrow_delta(ctx['delta_month'])} over the past month")
+
+        if ctx["target_kg"] is not None and ctx["delta_target"] is not None:
+            dt = ctx["delta_target"]
+            if abs(dt) < 0.3:
+                lines.append(f"   🎯 At your *{ctx['target_kg']:.0f} kg* target")
+            else:
+                direction = "to lose" if dt > 0 else "to gain"
+                lines.append(f"   🎯 *{abs(dt):.1f} kg {direction}* — target {ctx['target_kg']:.0f} kg")
+
+            pace = ctx["pace_kg_per_wk"]
+            # Only narrate pace if it's heading toward the target.
+            if pace is not None and abs(pace) >= 0.05:
+                target_heading = "down" if dt > 0 else "up"
+                pace_heading = "down" if pace < 0 else "up"
+                if target_heading == pace_heading:
+                    weeks = max(1, round(abs(dt) / max(0.05, abs(pace))))
+                    lines.append(
+                        f"   📈 Trend: {_fmt_arrow_delta(pace * 4)} per month "
+                        f"— at this pace, ~{weeks} week(s) to target"
+                    )
+                else:
+                    lines.append(
+                        f"   📈 Trend: {_fmt_arrow_delta(pace * 4)} per month "
+                        f"(opposite direction from target)"
+                    )
+
+    else:  # mode == "evening" — keep it compact
+        lines.append(f"⚖️ Weight: *{cur:.1f} kg*")
+
+        # Combine day + week deltas into one line if both present.
+        deltas: list[str] = []
+        if ctx["delta_day"] is not None:
+            deltas.append(f"{_fmt_arrow_delta(ctx['delta_day'])} vs yesterday")
+        if ctx["delta_week"] is not None:
+            deltas.append(f"{_fmt_arrow_delta(ctx['delta_week'])} vs last week")
+        if deltas:
+            lines.append("   " + " • ".join(deltas))
+
+        if ctx["target_kg"] is not None and ctx["delta_target"] is not None:
+            dt = ctx["delta_target"]
+            if abs(dt) < 0.3:
+                lines.append(f"   🎯 At your *{ctx['target_kg']:.0f} kg* target")
+            else:
+                direction = "to lose" if dt > 0 else "to gain"
+                lines.append(f"   🎯 *{abs(dt):.1f} kg {direction}* to your {ctx['target_kg']:.0f} kg target")
+
+    return "\n".join(lines)
+
+
+def _fmt_weight_context_for_prompt(user_id: int) -> str:
+    """Compact text block describing the user's current weight situation,
+    suitable for injection into an LLM system prompt (answer_question,
+    evening_summary's analysis paragraph, weekly_review).
+
+    Returns empty string if there's no weight data.
+    """
+    ctx = _weight_context(user_id)
+    cur = ctx["current_kg"]
+    if cur is None:
+        return ""
+
+    parts = [f"Weight today: {cur:.1f} kg"]
+    if ctx["yesterday_kg"] is not None:
+        parts.append(f"yesterday {ctx['yesterday_kg']:.1f} kg")
+    if ctx["week_ago_kg"] is not None:
+        parts.append(f"a week ago {ctx['week_ago_kg']:.1f} kg")
+    if ctx["month_ago_kg"] is not None:
+        parts.append(f"a month ago {ctx['month_ago_kg']:.1f} kg")
+    if ctx["pace_kg_per_wk"] is not None:
+        sign = "down" if ctx["pace_kg_per_wk"] < 0 else "up"
+        parts.append(f"30-day trend: {sign} {abs(ctx['pace_kg_per_wk']):.2f} kg/week")
+    if ctx["target_kg"] is not None:
+        if ctx["delta_target"] is not None:
+            dt = ctx["delta_target"]
+            if abs(dt) < 0.3:
+                parts.append(f"AT target ({ctx['target_kg']:.0f} kg)")
+            else:
+                direction = "to lose" if dt > 0 else "to gain"
+                parts.append(f"{abs(dt):.1f} kg {direction} to reach target {ctx['target_kg']:.0f} kg")
+        else:
+            parts.append(f"target {ctx['target_kg']:.0f} kg")
+
+    return "Weight context — " + "; ".join(parts) + "."
+
+
+# ─────────────────────────────────────────────────────────────────────────────
 # 5. Day summary -works for any date (today, yesterday, etc.)
 # ─────────────────────────────────────────────────────────────────────────────
 
@@ -827,6 +1069,9 @@ def evening_summary(user_id: int) -> str:
     eaten = today_totals.get("kcal", 0)
     pct = int(eaten / goal * 100) if goal else 0
 
+    # Compact weight context block — empty string if no readings yet.
+    weight_context_for_prompt = _fmt_weight_context_for_prompt(user_id)
+
     prompt = f"""You are a supportive personal nutritionist sending a short evening check-in message.
 
 Today's summary:
@@ -835,6 +1080,7 @@ Today's summary:
 - Fat: {today_totals.get('fat_g', 0):.0f}g
 - Carbs: {today_totals.get('carbs_g', 0):.0f}g
 {f'- Estimated burn: {burned:.0f} kcal (net {eaten - burned:.0f} kcal)' if burned else ''}
+{weight_context_for_prompt}
 
 Last 5 days:
 {past_lines}
@@ -843,8 +1089,8 @@ Last 5 days:
 
 Write a SHORT evening message in exactly 3 separate paragraphs (one sentence each, separated by a blank line):
 
-Paragraph 1: What went well today — be specific (mention protein, staying under goal, balance, variety, etc.)
-Paragraph 2: A pattern you notice from the last 5 days (e.g. consistently low protein, good calorie control, heavy on carbs, etc.)
+Paragraph 1: What went well today — be specific (mention protein, staying under goal, balance, variety, etc.). If weight context is provided, you may reference it here when relevant.
+Paragraph 2: A pattern you notice from the last 5 days (e.g. consistently low protein, good calorie control, heavy on carbs, etc.). If a clear weight trend exists, you can highlight that instead.
 Paragraph 3: One concrete, actionable tip for tomorrow based on what you see.
 
 Be warm and specific, not generic. Use Telegram formatting: *bold* for emphasis only.
@@ -858,10 +1104,13 @@ Reply in the same language the user typically uses."""
 
     analysis = response.content[0].text.strip()
 
-    # Assemble in the new order: totals → analysis → meal overview.
-    # The meals block comes from day_summary() with include_totals=False so
-    # the totals aren't duplicated (we already put them at the top).
+    # Assemble: totals → weight → analysis → meal overview.
+    # The weight block goes second so the headline numbers (kcal + weight)
+    # are both visible at a glance before the analysis paragraphs.
+    # The meals block uses include_totals=False so the totals aren't
+    # duplicated (we already put them at the top).
     totals_block = f"📋 *Today:*\n\n{_fmt_totals(today_totals, goal)}"
+    weight_block = _fmt_weight_block(user_id, mode="evening")
     meals_block = day_summary(
         user_id,
         date.today().isoformat(),
@@ -869,7 +1118,12 @@ Reply in the same language the user typically uses."""
         include_totals=False,
     )
 
-    return f"{totals_block}\n\n💬 {analysis}\n\n{meals_block}"
+    parts = [totals_block]
+    if weight_block:
+        parts.append(weight_block)
+    parts.append(f"💬 {analysis}")
+    parts.append(meals_block)
+    return "\n\n".join(parts)
 
 
 def today_summary(user_id: int) -> str:

--- a/lint.py
+++ b/lint.py
@@ -338,6 +338,184 @@ def _append_log(user_id: int, per_page: dict[str, dict]) -> None:
 # Main entry
 # ─────────────────────────────────────────────────────────────────────────────
 
+# ─────────────────────────────────────────────────────────────────────────────
+# Proactive weight-pattern observations (issue #7 surfacing)
+#
+# Each Saturday lint pass also checks the user's weight history and, if a
+# clear trend / plateau / milestone is present, appends a dated observation
+# to patterns.md. The bot's existing patterns.md format expects bullet lines
+# stamped with [YYYY-MM-DD], so these entries plug in cleanly.
+#
+# Deterministic templates — we don't use an LLM here. The observations are
+# short, factual, and dated. The LLM-driven summaries (evening, weekly,
+# Q&A) then surface these as part of the wiki context.
+# ─────────────────────────────────────────────────────────────────────────────
+
+# A pattern is "interesting enough to add to the wiki" when:
+#   - sustained trend ≥ 0.2 kg/week (absolute) over ≥ 3 weeks → "trending down/up"
+#   - plateau: max-min over the past 14 days < 0.4 kg                 → "steady"
+#   - milestone: crossed below/above an integer kg in the past 7 days → "crossed"
+#
+# All thresholds tuned to be conservative — we'd rather miss a borderline
+# trend than spam patterns.md with noise.
+
+_WEIGHT_TREND_KG_PER_WEEK_THRESHOLD = 0.2
+_WEIGHT_TREND_MIN_WEEKS = 3
+_WEIGHT_PLATEAU_WINDOW_DAYS = 14
+_WEIGHT_PLATEAU_BAND_KG = 0.4
+_WEIGHT_MILESTONE_WINDOW_DAYS = 7
+
+
+def _detect_weight_observations(user_id: int) -> list[str]:
+    """Return a list of single-sentence observations about this user's weight
+    over the last ~30 days. Empty list if nothing notable. Each string is
+    ready to be wrapped in a `- [YYYY-MM-DD] ...` bullet.
+
+    Imported lazily to keep the lint module's top-level imports independent
+    of database (lint pages are about wiki content, not DB schemas).
+    """
+    import database as db
+    from datetime import date, timedelta
+
+    today = date.today()
+    since = (today - timedelta(days=35)).isoformat()
+    history = db.get_daily_min_weights(user_id, since=since)
+    if len(history) < 7:
+        return []   # not enough data to say anything meaningful
+
+    observations: list[str] = []
+    values = [(date.fromisoformat(r["date"]), r["weight_kg"]) for r in history]
+
+    # ── Sustained trend ──────────────────────────────────────────────────────
+    # Fit a simple end-to-end average and report if ≥ threshold for ≥ 3 weeks.
+    first_d, first_w = values[0]
+    last_d, last_w = values[-1]
+    span_days = max(1, (last_d - first_d).days)
+    if span_days >= _WEIGHT_TREND_MIN_WEEKS * 7:
+        kg_per_wk = (last_w - first_w) / span_days * 7
+        if abs(kg_per_wk) >= _WEIGHT_TREND_KG_PER_WEEK_THRESHOLD:
+            direction = "down" if kg_per_wk < 0 else "up"
+            observations.append(
+                f"Weight trending {direction} ~{abs(kg_per_wk):.2f} kg/week "
+                f"over the past {span_days // 7} weeks"
+            )
+
+    # ── Plateau ──────────────────────────────────────────────────────────────
+    plateau_window = [
+        (d, w) for d, w in values
+        if (today - d).days <= _WEIGHT_PLATEAU_WINDOW_DAYS
+    ]
+    if len(plateau_window) >= 5:
+        weights_window = [w for _, w in plateau_window]
+        band = max(weights_window) - min(weights_window)
+        if band < _WEIGHT_PLATEAU_BAND_KG:
+            avg = sum(weights_window) / len(weights_window)
+            observations.append(
+                f"Weight steady around {avg:.1f} kg (within ±{band/2:.1f} kg "
+                f"for {len(plateau_window)} days)"
+            )
+
+    # ── Milestone: crossed an integer kg recently ────────────────────────────
+    # If today's weight is below floor(prior weight) — i.e. crossed below
+    # the next-lower integer — in the past 7 days, flag it.
+    import math
+    recent = [(d, w) for d, w in values if (today - d).days <= _WEIGHT_MILESTONE_WINDOW_DAYS]
+    older  = [(d, w) for d, w in values if (today - d).days >  _WEIGHT_MILESTONE_WINDOW_DAYS]
+    if recent and older:
+        cur = recent[-1][1]
+        prior = older[-1][1]
+        cur_floor = math.floor(cur)
+        prior_floor = math.floor(prior)
+        if cur_floor < prior_floor:
+            observations.append(
+                f"Crossed below {prior_floor} kg (now {cur:.1f} kg)"
+            )
+        elif cur_floor > prior_floor:
+            observations.append(
+                f"Crossed above {prior_floor + 1} kg (now {cur:.1f} kg)"
+            )
+
+    return observations
+
+
+def _existing_weight_observations(content: str) -> set[str]:
+    """Pull the gist of any existing weight bullets out of patterns.md so we
+    don't append a near-duplicate this week.
+
+    Match heuristic: anything containing the word 'weight' OR 'kg' inside a
+    bullet line. We compare on the lowercase-stripped string to avoid
+    re-stamping a week-old observation that's still true.
+    """
+    out: set[str] = set()
+    for line in content.splitlines():
+        s = line.strip()
+        if not s.startswith(("- ", "* ", "• ")):
+            continue
+        low = s.lower()
+        if "weight" in low or " kg" in low:
+            # Strip bullet marker + date prefix for similarity match
+            body = re.sub(r"^[\s\-\*•]+", "", s).strip()
+            body = re.sub(r"^\[\d{4}-\d{2}-\d{2}\]\s*", "", body).strip()
+            out.add(body.lower())
+    return out
+
+
+def _append_weight_observations(user_id: int) -> int:
+    """Detect any notable weight patterns and append new (non-duplicate) ones
+    to patterns.md as dated bullets. Returns the number of new bullets added.
+    Caller holds `wiki.get_lock(user_id)`.
+    """
+    new_obs = _detect_weight_observations(user_id)
+    if not new_obs:
+        return 0
+
+    existing = wiki.read_page(user_id, "patterns") or ""
+    existing_low = _existing_weight_observations(existing)
+    date_str = datetime.now().strftime("%Y-%m-%d")
+
+    appended: list[str] = []
+    for obs in new_obs:
+        # Skip if a similar observation is already in patterns.md.
+        if any(_observations_match(obs, e) for e in existing_low):
+            continue
+        appended.append(f"- [{date_str}] {obs}")
+
+    if not appended:
+        return 0
+
+    # Strip the empty-placeholder line if it's still there (self-healing).
+    cleaned = wiki.strip_empty_placeholder(existing).rstrip()
+    new_content = cleaned + "\n" + "\n".join(appended) + "\n"
+    wiki.write_page(user_id, "patterns", new_content)
+
+    # Leave a breadcrumb in log.md for each new observation, matching the
+    # existing append-to-page audit convention.
+    for line in appended:
+        wiki.append_log(
+            user_id,
+            "Added to patterns.md (weight observation)",
+            line,
+        )
+
+    _log.info(
+        f"user={user_id} appended {len(appended)} weight observation(s)"
+    )
+    return len(appended)
+
+
+def _observations_match(a: str, b: str) -> bool:
+    """Loose similarity check between two weight observations — same notion
+    (trending up vs trending down vs steady vs crossed) → match.
+    Prevents stamping "Weight trending down 0.3 kg/week" when patterns.md
+    already has "Weight trending down 0.25 kg/week" from last week.
+    """
+    al, bl = a.lower(), b.lower()
+    for keyword in ("trending down", "trending up", "steady", "crossed below", "crossed above"):
+        if keyword in al and keyword in bl:
+            return True
+    return False
+
+
 async def lint_user_wiki(user_id: int) -> dict:
     """
     Run a lint pass over every lintable page for this user.
@@ -430,6 +608,37 @@ async def lint_user_wiki(user_id: int) -> dict:
         except Exception as e:
             # Consolidation must never break a lint pass; log and move on.
             _log.warning(f"user={user_id} consolidate_goal_line failed: {e}")
+
+        # Same belt-and-braces pass for the target-weight canonical line.
+        try:
+            consol_tw = wiki.consolidate_target_weight_line(user_id)
+            if consol_tw.get("rewrote"):
+                _log.info(
+                    f"user={user_id} consolidated target weight line: "
+                    f"found={consol_tw['found']} kept={consol_tw['kept']}"
+                )
+        except Exception as e:
+            _log.warning(f"user={user_id} consolidate_target_weight_line failed: {e}")
+
+        # Proactive weight-pattern observations (issue #7). Detects clear
+        # trends / plateaus / milestones from weight_readings and appends
+        # dated bullets to patterns.md when something new is worth noting.
+        # Errors are swallowed so a missing weight feature can't break lint.
+        try:
+            n_added = _append_weight_observations(user_id)
+            if n_added:
+                # Fold into the patterns result so the lint summary shows it.
+                patterns_info = result.get("patterns", {})
+                after_lines = _line_count(wiki.read_page(user_id, "patterns"))
+                patterns_info["after"] = after_lines
+                patterns_info["rewritten"] = True
+                patterns_info["weight_observations_added"] = n_added
+                # If patterns was previously skipped (empty), it isn't empty now.
+                patterns_info.pop("skipped", None)
+                patterns_info.setdefault("before", after_lines - n_added)
+                result["patterns"] = patterns_info
+        except Exception as e:
+            _log.warning(f"user={user_id} weight observations failed: {e}")
 
         # After all pages done, append the summary to log.md (still holding
         # the lock, so we're safe from concurrent writes).


### PR DESCRIPTION
Second half of issue #7. After this lands, weight data flowing from the hourly Withings sync (PR A) becomes user-visible in the evening push, the Sunday review, and Q&A — plus the bot starts noting weight trends in patterns.md on Saturdays.

What this PR adds:

advisor.py — weight analysis + display helpers:
  - _weight_context(user_id) — pulls last 35 days of readings, returns current_kg (today's morning-low if available), yesterday_kg, week_ago_kg, month_ago_kg, signed deltas, target_kg from goals.md, delta_target, pace_kg_per_wk (linear end-to-end trend, needs ≥14 days of data), and the raw history list. The "look up the weight at N days ago" uses a ±2-day search window so we don't return None just because the user skipped a weighing.
  - _fmt_arrow_delta(delta) — renders signed deltas with arrows (↓ 0.2 kg, ↑ 0.3 kg, "steady" for ≤ 0.05 kg).
  - _fmt_weight_block(user_id, mode) — formatted block for summaries. mode="evening" → compact (current + day/week deltas + target distance). mode="weekly" → richer (week start→current, month delta, target distance, pace-per-month + weeks-to-target projection).
  - _fmt_weight_context_for_prompt(user_id) — compact text injection for Sonnet system prompts.

evening_summary surfacing:
  - Weight block inserted between the totals block and the AI analysis so headline numbers (kcal + weight) appear before the prose.
  - Prompt also gets the weight-context string so the AI analysis can weave in weight references when relevant ("good day on protein, and your weight is down 0.3 kg week-over-week").

weekly_review surfacing:
  - Replaced the old weight-line heuristic (which read from daily_stats and showed only first→last in the week) with _fmt_weight_block in "weekly" mode — start→current, month delta, target progress, and a pace projection when the trend is heading toward the target.
  - Prompt gets the weight context so the 3-paragraph review can connect eating patterns with weight movement.

answer_question surfacing:
  - System prompt now includes _fmt_weight_context_for_prompt output, so "how's my weight?" / "am I on track?" / "should I cut calories?" type questions get concrete, data-anchored answers.

lint.py — proactive weight observations into patterns.md (Saturday cron):
  - _detect_weight_observations(user_id) computes three categories of pattern from the past 30 days of readings: • Sustained trend ≥ 0.2 kg/week over ≥ 3 weeks • Plateau: max-min < 0.4 kg over the last 14 days • Milestone: crossed an integer-kg boundary in the last 7 days Conservative thresholds — would rather miss a borderline trend than spam patterns.md.
  - _existing_weight_observations + _observations_match dedup against last week's bullets so "trending down" doesn't get re-stamped every Saturday.
  - _append_weight_observations writes new bullets in the same `- [YYYY-MM-DD] text` format ingest uses, leaving log.md breadcrumbs to match the existing audit convention.
  - Wired into lint_user_wiki as a third post-pass, alongside consolidate_goal_line. Also added consolidate_target_weight_line as a second post-pass (mirrors the kcal consolidator for the new target weight line).

ARCHITECTURE.md:
  - §8.3A — new subsection documenting the four weight helpers, their return shapes, and where each is wired in.
  - §9.5 — lint_user_wiki post-passes expanded from 1 to 3 (consolidate_goal_line + consolidate_target_weight_line + _append_weight_observations).
  - §12 — user-visible table updated to call out weight in evening + Sunday + the silent hourly sync; the internal side notes weight-pattern observations going into patterns.md.

Smoke-tested with 30 days of synthetic readings + a target weight set in goals.md: morning-low rule fires correctly, deltas are stable (66.6 vs yesterday's 66.6 reads as "steady", not noisy "↓ 0.03 kg"), pace projection produces sane "~22 weeks to target" framing, and the weight-trend detector correctly flagged a 4-week downtrend.

Closes #7