### PR TITLE
Fix weight question routing + semantic topic tag in intent classifier

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -414,7 +414,7 @@ This is the biggest handler. Five things happen, in order:
 | `correction` | After the bot just logged a meal and the user is fixing it (*"actually three eggs"*, *"that was lunch"*, *"remove the hummus"*). | Fetch today's full meal log + last logged batch, run `analyzer.resolve_correction`, integrity-guard the meal_ids, apply each action (`update` / `delete` / `scale_dish_grams` / `scale_dish` / `delete_many` / `delete_duplicates` / `add_items` / `update_many`). |
 | `question` | User asks for advice or a number (*"how much protein today?"*, *"what should I eat for dinner?"*, *"give me a recipe for X"*, or any follow-up to bot suggestions). | `advisor.answer_question` + fire-and-forget `advisor.schedule_ingest('question', ...)`. |
 | `cmd_today` | Natural-language ask for today's summary. | `advisor.today_summary`. |
-| `cmd_date_query` | Asks about a specific past day (*"yesterday"*, *"Tuesday"*, *"April 7th"*). | `analyzer.extract_query_date` → `advisor.day_summary`. |
+| `cmd_date_query` | Asks about FOOD for a specific past day (*"what did I eat yesterday"*, *"my meals on Tuesday"*, *"food on April 7th"*). Weight, body metric, or stat questions about a past day go to `question` instead — see the intent prompt for the explicit list. | `analyzer.extract_query_date` → `advisor.day_summary`. |
 | `cmd_week` | Wants the FULL weekly review (*"weekly review"*, *"how was my week"*). | `advisor.weekly_review`. Specific-aspect-of-this-week questions go to `question`, not `cmd_week`. |
 | `cmd_goal` | Set a calorie number (*"set my goal to 1800"*). Bare number-extraction via `analyzer.extract_goal_from_text`. | `wiki.set_daily_kcal` under the per-user lock. |
 | `cmd_lint` | User asks the bot to tidy / clean / dedupe its own notes. | Delegates to `cmd_lint`. |
@@ -912,18 +912,43 @@ transcript. Assistant turns longer than 400 characters are truncated —
 the router only needs the gist of what the bot just said.
 **Called from:** `detect_intent`, `resolve_correction`.
 
-#### `detect_intent(text, history=None) → str`
+#### `detect_intent(text, history=None) → (intent, topic)`
+
+Returns a **tuple** of `(intent, topic)`.
+
 Three short-circuits before the LLM call: messages starting with `/`
-return `"command"`; messages starting with the iPhone Shortcut prefixes
-(`📊 health`, `🏋️ workouts`) return `health_update` / `workout_log`.
+return `("command", None)`; messages starting with the iPhone Shortcut
+prefixes (`📊 health`, `🏋️ workouts`) return `("health_update", None)`
+/ `("workout_log", None)`.
+
 Otherwise asks Haiku for one of: `log_text`, `correction`, `question`,
 `cmd_today`, `cmd_date_query`, `cmd_week`, `cmd_goal`, `cmd_lint`,
-`remember`. Cleans the LLM reply tolerantly (strips quotes, backticks,
-punctuation) and falls back to **keyword heuristics on API errors** —
-including "change", "fix", "wrong", "actually", "remove", "delete"
-(and Russian "поменя", "измени", "исправ", "удали") → `correction`;
-"how", "what", "сколько" or trailing `?` → `question`; otherwise
-`log_text`.
+`remember` — optionally with a `:weight` suffix for `question` intent.
+
+**Topic tagging (issue #24).** The intent classifier prompt instructs
+Haiku to append `:weight` to `question` when the message is about
+weight, body composition, body progress, fitness changes, scale data,
+or related body metrics — *semantically*, not via keywords. So *"show
+me my body progress"* → `question:weight` even though the word
+"weight" isn't there. Examples in the prompt anchor the behaviour.
+
+Topic values currently recognised: `"weight"` only. Any other suffix
+Haiku might output (`question:food`, `question:other`, …) is silently
+ignored — we'd rather drop a tag than misroute on garbage. The intent
+itself is still accepted regardless.
+
+The parsing splits on the first `:`, validates each half independently,
+and falls back to the existing valid-word search if the intent part
+isn't recognised.
+
+Cleans the LLM reply tolerantly (strips quotes, backticks, trailing
+punctuation; preserves `:` so the topic survives). Falls back to
+**keyword heuristics on API errors** — including "change", "fix",
+"wrong", "actually", "remove", "delete" (and Russian "поменя",
+"измени", "исправ", "удали") → `("correction", None)`; "how", "what",
+"сколько" or trailing `?` → `("question", None)`; otherwise
+`("log_text", None)`. No topic tagging in the fallback — when the API
+is down, the snapshot-only weight context is acceptable.
 
 ### 7.6 Date + goal + activity helpers
 
@@ -1033,11 +1058,56 @@ string if there's no data.
   distance, and a "pace per month + weeks-to-target" projection when
   the trend is heading toward the target.
 
-#### `_fmt_weight_context_for_prompt(user_id) → str`
+#### `_fmt_weight_context_for_prompt(user_id, include_history=False) → str`
 
-Compact text describing the weight situation, suitable for injection
-into a Sonnet system prompt (`answer_question`, `evening_summary`,
-`weekly_review`). Empty string if no data.
+Two-tier weight summary for injection into Sonnet's system prompt
+(`answer_question`, `evening_summary`, `weekly_review`). Empty string
+if there's no weight data.
+
+**Tier 1 — always sent** (when there's data, regardless of the flag):
+1. *"Weight context — Weight today: …; yesterday …; …"* — the
+   snapshot (current + day/week/month deltas + pace + target distance).
+2. *"Lifetime span: FIRST → LAST (N readings, lifetime min X, max Y)."*
+   — one-line global anchor from `db.get_lifetime_weight_stats`.
+
+These are ~200 tokens total — negligible cost. Sent on every Sonnet
+call that uses this helper.
+
+**Tier 2 — opt-in via `include_history=True`**:
+3. *"Daily weight history (oldest first; each row is that day's
+   morning-low):"* — the full daily-min series from
+   `db.get_daily_min_weights`. One row per day Maria weighed in,
+   in the form `YYYY-MM-DD  X.X`. Sonnet computes whatever
+   aggregation the question needs (weekly average, quarterly median,
+   year-over-year, trend over arbitrary window, …) from this series.
+
+This section is ~8 k tokens for 5 years of data. Reserved for cases
+where the user is likely to ask a statistical question:
+
+| Caller | `include_history` | Rationale |
+| --- | --- | --- |
+| `weekly_review` | `True` | Trend analysis is the whole point. Once/week → cheap. |
+| `evening_summary` | `False` (default) | AI analysis is meal-focused; snapshot is plenty. |
+| `answer_question` | `topic == "weight"` | Driven by the intent classifier's `:weight` tag (issue #24) — semantic classification, free, no added latency. See §7.5 detect_intent. |
+
+The deliberate design choice (per issue #24) is to **not pre-bake
+specific aggregations** (monthly / yearly / weekly / etc.) — that
+forces us to anticipate every question shape, and weight questions
+come in too many flavours. The lifetime line + daily-min series
+together give Sonnet enough to compute essentially any
+statistical-aggregation question without us writing per-question
+handlers.
+
+Why the topic tag and not a keyword check: keyword matching misses
+synonyms and oblique phrasings (*"show me my body progress"*, *"how
+am I changing physically?"*, *"am I getting leaner?"* — none contain
+"weight" / "kg" / "lose"). Haiku-driven semantic classification picks
+those up correctly. The classification rides on the existing intent
+call so it costs zero extra API time or money.
+
+Approximate monthly cost added (Sonnet 4.6 at $3/M input):
+~$0.50–$2.00 depending on question volume (1–15 weight questions per
+day). Without the gating it would be ~$4–7/month.
 
 #### Surfacing — where each helper is used
 

--- a/advisor.py
+++ b/advisor.py
@@ -519,7 +519,9 @@ def weekly_review(user_id: int) -> str:
     )
 
     profile = wiki.read_wiki_for_prompt(user_id)
-    weight_context_for_prompt = _fmt_weight_context_for_prompt(user_id)
+    # Weekly review's whole point is trend analysis — always send the full
+    # daily history so Sonnet can talk concretely about the week + longer arc.
+    weight_context_for_prompt = _fmt_weight_context_for_prompt(user_id, include_history=True)
 
     prompt = f"""You are a supportive personal nutritionist sending a detailed Sunday weekly review to your client.
 
@@ -555,7 +557,12 @@ Reply in the same language the user typically uses."""
 # 4. Answer user nutrition questions
 # ─────────────────────────────────────────────────────────────────────────────
 
-def answer_question(user_id: int, question: str, conversation: list[dict] | None = None) -> str:
+def answer_question(
+    user_id: int,
+    question: str,
+    conversation: list[dict] | None = None,
+    topic: Optional[str] = None,
+) -> str:
     """
     Answer any nutrition question -data queries AND general advice.
     Acts as a knowledgeable personal nutritionist, not just a data lookup.
@@ -564,6 +571,11 @@ def answer_question(user_id: int, question: str, conversation: list[dict] | None
     dicts, oldest first, ending with the current user question). When
     supplied it's passed as the messages list so follow-ups ("and what
     about if I add cardio?") retain context from earlier turns.
+
+    topic: optional classification tag from `analyzer.detect_intent`.
+    Currently the only recognised topic is `"weight"`, which triggers the
+    heavy daily-history weight context (issue #24). Anything else (or
+    None) gets the lightweight snapshot only.
     """
     user = db.get_user(user_id) or {}
     goal = wiki.get_daily_kcal(user_id, 2000)
@@ -571,7 +583,15 @@ def answer_question(user_id: int, question: str, conversation: list[dict] | None
     week = db.get_week_totals(user_id)
 
     profile = wiki.read_wiki_for_prompt(user_id)
-    weight_context_for_prompt = _fmt_weight_context_for_prompt(user_id)
+    # Two-tier weight context (issue #24): always send the cheap snapshot,
+    # only send the token-heavy daily history when the intent router (Haiku)
+    # tagged this question as `:weight`. Saves ~$3-5/month vs unconditional
+    # injection while still being semantic — Haiku catches synonyms and
+    # oblique phrasings ("how am I changing", "body progress", etc.)
+    # without us maintaining a keyword list.
+    weight_context_for_prompt = _fmt_weight_context_for_prompt(
+        user_id, include_history=(topic == "weight")
+    )
     context = f"""You are a friendly, knowledgeable personal nutritionist.
 You have access to the user's food tracking data below. Use it when relevant.
 
@@ -934,12 +954,27 @@ def _fmt_weight_block(user_id: int, mode: str = "evening") -> str:
     return "\n".join(lines)
 
 
-def _fmt_weight_context_for_prompt(user_id: int) -> str:
+def _fmt_weight_context_for_prompt(
+    user_id: int,
+    include_history: bool = False,
+) -> str:
     """Compact text block describing the user's current weight situation,
-    suitable for injection into an LLM system prompt (answer_question,
-    evening_summary's analysis paragraph, weekly_review).
+    suitable for injection into an LLM system prompt (`answer_question`,
+    `evening_summary`, `weekly_review`).
 
-    Returns empty string if there's no weight data.
+    Two-tier context (issue #24):
+      - **Always included** (when there's any data at all): the snapshot
+        line (current + day/week/month deltas + target distance) plus a
+        one-line lifetime summary. Small, ~200 tokens, negligible cost.
+      - **Optional via `include_history=True`**: the full daily-min series
+        (one row per day, ~17 chars each). Lets Sonnet compute any
+        statistical aggregation the user asks for — weekly average,
+        monthly median, year-over-year, arbitrary windows — instead of
+        us pre-baking specific aggregations. Roughly 8 k extra tokens
+        for 5 years of data, so reserved for cases where it's likely
+        to be used (weight-specific questions, weekly review).
+
+    Returns empty string if there's no weight data at all.
     """
     ctx = _weight_context(user_id)
     cur = ctx["current_kg"]
@@ -967,7 +1002,49 @@ def _fmt_weight_context_for_prompt(user_id: int) -> str:
         else:
             parts.append(f"target {ctx['target_kg']:.0f} kg")
 
-    return "Weight context — " + "; ".join(parts) + "."
+    sections = ["Weight context — " + "; ".join(parts) + "."]
+
+    # ── Lifetime summary (one tiny line) ────────────────────────────────────
+    # Cheap, accurate anchor for "lowest ever", "how long have I been
+    # tracking", overall span. Sonnet uses this when it just needs a global
+    # number rather than computing across the full series below.
+    lt = db.get_lifetime_weight_stats(user_id)
+    if lt:
+        first_d = lt["first_at"][:10] if lt.get("first_at") else "?"
+        last_d  = lt["last_at"][:10]  if lt.get("last_at")  else "?"
+        sections.append(
+            f"Lifetime span: {first_d} → {last_d} "
+            f"({lt['count']} readings, lifetime min {lt['min_kg']:.1f} kg, "
+            f"lifetime max {lt['max_kg']:.1f} kg)."
+        )
+
+    # ── Raw daily-min series — opt-in (token-heavy) ─────────────────────────
+    # Sent only when `include_history=True` because it's ~8 k tokens for 5
+    # years of data. Callers gate on whether the model is likely to need it:
+    #   - weekly_review: always True (trend analysis is the point)
+    #   - answer_question: True iff _is_weight_question(text) matches
+    #   - evening_summary: False (analysis is meal-focused; snapshot is enough)
+    #
+    # daily_min is the morning-low for each day = the conventional "true"
+    # weight. Sonnet computes whatever aggregation the user asks for —
+    # weekly average, monthly median, yearly mean, year-over-year, rolling
+    # trend, arbitrary windows — instead of us pre-baking per-question
+    # handlers (issue #24).
+    if include_history:
+        daily = db.get_daily_min_weights(user_id)   # all history, oldest first
+        if daily:
+            lines = [
+                "Daily weight history (oldest first; each row is that day's "
+                "morning-low = the canonical 'true' weight for that date). "
+                "Use this series to compute any statistic the user asks for — "
+                "weekly average, monthly median, yearly mean, year-over-year, "
+                "rolling trend, whatever:"
+            ]
+            for d in daily:
+                lines.append(f"  {d['date']}  {d['weight_kg']:.1f}")
+            sections.append("\n".join(lines))
+
+    return "\n\n".join(sections)
 
 
 # ─────────────────────────────────────────────────────────────────────────────

--- a/analyzer.py
+++ b/analyzer.py
@@ -782,7 +782,7 @@ Intents:
   correction    — fixing, adjusting, or deleting a just-logged entry (quantity, count, name, meal type, or removal). See context rule above.
   question      — asking for advice, information, analysis, a recipe, or cooking instructions (e.g. "how much protein today?", "what should my calorie goal be?", "is my diet balanced?", "what should I eat for dinner?", "give me a recipe for X", "how do I cook X?"). Also any follow-up to bot-offered suggestions/options — see context rule above.
   cmd_today     — wants to see TODAY's food log summary (e.g. "show today", "what did I eat today", "today's summary")
-  cmd_date_query — wants to see food log for a SPECIFIC past day (e.g. "what did I eat yesterday", "show yesterday", "what did I eat on Tuesday", "my food last Monday", "show me Wednesday", "what was my food on April 7th")
+  cmd_date_query — wants to see FOOD LOG for a specific past day (e.g. "what did I eat yesterday", "show yesterday", "what did I eat on Tuesday", "my food last Monday", "show me Wednesday", "what was my food on April 7th"). ONLY for food/meal queries about a past day — NOT for weight, body metrics, or any other stat. Weight questions about a past day are always `question`, see below.
   cmd_week      — wants the FULL weekly review/summary covering everything (e.g. "weekly review", "how was my week overall", "give me my Sunday review", "show me this week"). NOT when the user asks about a specific nutrient, meal, or aspect — those are questions, even when they mention "this week".
   cmd_goal      — wants to CHANGE or SET their calorie goal to a specific number (e.g. "set my goal to 1800", "change my goal to 2200 calories") — NOT asking what it should be
   cmd_lint      — wants the bot to tidy up / clean up / dedupe / review its own notes or memory about the user (e.g. "lint", "tidy up", "tidy up your notes", "clean up your notes", "dedup my notes", "dedupe", "clean up my profile", "sort out your memory", "review your notes about me", "check your notes for contradictions"). This is about the bot's own housekeeping of what it remembers — NOT about the user's food log or daily summary.
@@ -797,8 +797,21 @@ IMPORTANT:
 - "set my goal to 1800" → cmd_goal (only when setting a specific number)
 - "I don't eat fish", "please remember I hate cilantro", "I'm lactose intolerant" → remember
 - "wait, actually this was breakfast" AFTER a just-logged meal → correction (meal-type change)
-- ANY mention of a specific past day when asking about food/eating → cmd_date_query (NOT cmd_today)
-  Examples: "yesterday", "Tuesday", "last Monday", "April 7th" → cmd_date_query
+- A specific past day mentioned together WITH a food/meal query → cmd_date_query (NOT cmd_today). The query MUST be about food/eating; a past day alone isn't enough.
+  Examples (all about food on that day): "what did I eat yesterday", "show me Tuesday's meals", "my food last Monday", "what was my food on April 7th" → cmd_date_query
+- Weight, body metrics, weight goals, weight trends, weight averages — ALWAYS `question`, even when a specific day, month, or week is mentioned. The bot has full weight history and Sonnet can answer trend / split / average questions concretely. Examples (ALL → question):
+    "what's my weight?" → question
+    "what was my weight in April" → question
+    "tell me my weight in April" → question
+    "how's my weight trend?" → question
+    "what's my average weight this month?" → question
+    "what's my average weight split by months?" → question
+    "how much have I lost this month?" → question
+    "what was my weight yesterday?" → question
+    "am I on track for my target weight?" → question
+    "how's my weight progress?" → question
+    "what was my lowest weight last year?" → question
+  cmd_date_query is ONLY for "what did I eat on day X" style queries about FOOD.
 - Specific-topic questions that happen to mention "this week" are STILL questions, not cmd_week:
     "how's my protein this week?" → question
     "am I hitting my calorie goal this week?" → question
@@ -819,7 +832,42 @@ IMPORTANT:
     "how's my diet looking?" → question
     "audit my food this week" → question
 
-Reply with ONLY the intent word, nothing else. No explanation, no punctuation."""
+OUTPUT FORMAT — intent word, optionally with a topic tag:
+
+By default reply with just the single intent word (correction, log_text,
+cmd_today, cmd_date_query, cmd_week, cmd_goal, cmd_lint, remember, or
+question). No explanation, no punctuation.
+
+For `question` intent ONLY, you MAY optionally append `:weight` when the
+question is about weight, body composition, body progress, fitness
+changes, scale data, or related body metrics — even when the user uses
+synonyms or oblique phrasings. This is a semantic check, not keyword
+matching: a question about "body progress" or "how I'm changing
+physically" is `question:weight` even without the word "weight".
+
+Examples — `question:weight`:
+  "what's my weight?" → question:weight
+  "tell me my weight in April" → question:weight
+  "what's my weight trend?" → question:weight
+  "what's my average weight split by months?" → question:weight
+  "how much have I lost this month?" → question:weight
+  "show me my body progress" → question:weight
+  "how am I changing physically?" → question:weight
+  "am I getting leaner?" → question:weight
+  "am I on track for my target weight?" → question:weight
+  "what was my lowest weight last year?" → question:weight
+  "what's my BMI trend?" → question:weight
+
+Examples — plain `question` (no topic suffix):
+  "how much protein did I eat today?" → question
+  "what should I have for dinner?" → question
+  "give me a recipe for chicken" → question
+  "is my diet balanced?" → question
+  "how many calories in an avocado?" → question
+
+ALL OTHER intents (correction, log_text, cmd_today, cmd_date_query,
+cmd_week, cmd_goal, cmd_lint, remember) NEVER get a topic suffix —
+just the intent word."""
 
 
 # Prefix tokens used by the iPhone Shortcuts — detected before calling intent API
@@ -854,10 +902,30 @@ def _format_transcript(history: list[dict]) -> str:
     return "\n\n".join(parts)
 
 
-def detect_intent(text: str, history: Optional[list[dict]] = None) -> str:
+def detect_intent(
+    text: str,
+    history: Optional[list[dict]] = None,
+) -> tuple[str, Optional[str]]:
     """
-    Classify the user's latest message into a router intent. Uses Haiku
-    so it works in any language. Falls back to 'log_text' on API errors.
+    Classify the user's latest message into a router intent + optional
+    topic tag. Uses Haiku so it works in any language. Falls back to
+    ('log_text', None) on API errors.
+
+    Returns a tuple `(intent, topic)`:
+      - intent: one of `log_text` / `correction` / `question` / `cmd_today` /
+        `cmd_date_query` / `cmd_week` / `cmd_goal` / `cmd_lint` / `remember`
+        / `command` / `health_update` / `workout_log`.
+      - topic: only meaningful when `intent == "question"`. Currently the
+        only recognised topic is `"weight"` (for any question about weight,
+        body composition, body progress, fitness changes, scale data —
+        semantic match, not keyword). `None` otherwise.
+
+    Topic-tag mechanism (issue #24): we ask Haiku — which already runs for
+    every text message — to optionally append `:weight` to the intent word
+    when it judges the question is weight-related. This gives semantic
+    classification without an extra API call or added latency. The change
+    is backward-compatible at the prompt level: Haiku may still output just
+    the intent word for any non-weight question.
 
     The short-term conversation `history` (list of {role, content} dicts,
     oldest first, ending with the current user turn) is rendered as a
@@ -868,14 +936,14 @@ def detect_intent(text: str, history: Optional[list[dict]] = None) -> str:
     the router firmly in classifier mode.
     """
     if text.strip().startswith("/"):
-        return "command"
+        return "command", None
 
     # iPhone Shortcuts send structured messages with these prefixes
     stripped = text.strip()
     if stripped.startswith(HEALTH_PREFIX):
-        return "health_update"
+        return "health_update", None
     if stripped.startswith(WORKOUT_PREFIX):
-        return "workout_log"
+        return "workout_log", None
 
     # Build ONE user message containing (a) the transcript so far, and
     # (b) the latest message to classify. The transcript excludes the
@@ -890,44 +958,64 @@ def detect_intent(text: str, history: Optional[list[dict]] = None) -> str:
             f"{transcript}\n"
             "---\n\n"
             f"Latest user message to classify:\n{text}\n\n"
-            "Reply with ONLY the intent word."
+            "Reply with the intent word (optionally `:weight` for question intents)."
         )
     else:
         user_prompt = (
             f"Latest user message to classify:\n{text}\n\n"
-            "Reply with ONLY the intent word."
+            "Reply with the intent word (optionally `:weight` for question intents)."
         )
 
     messages = [{"role": "user", "content": user_prompt}]
     history_len = len(history) if history else 0
 
+    valid = {"log_text", "correction", "question", "cmd_today",
+             "cmd_date_query", "cmd_week", "cmd_goal", "cmd_lint",
+             "remember"}
+
     try:
         response = client.messages.create(
             model="claude-haiku-4-5-20251001",
-            max_tokens=10,
+            max_tokens=12,   # was 10 — bumped to fit "question:weight" (15 chars / 4 tokens)
             system=INTENT_SYSTEM_PROMPT,
             messages=messages,
         )
         raw = response.content[0].text
-        # Be tolerant of stray decoration around the single-word answer:
-        # quotes, backticks, bold markers, trailing punctuation, etc.
-        # Before: a bare "question." was silently coerced to log_text.
-        cleaned = raw.strip().lower().strip("`\"'*_ .!?,:;")
-        valid = {"log_text", "correction", "question", "cmd_today",
-                 "cmd_date_query", "cmd_week", "cmd_goal", "cmd_lint",
-                 "remember"}
-        if cleaned in valid:
-            intent = cleaned
+        # Be tolerant of stray decoration around the answer: quotes,
+        # backticks, bold markers, trailing punctuation. Preserve `:` so
+        # the optional topic suffix survives.
+        cleaned = raw.strip().lower().strip("`\"'*_ .!?,;")
+
+        # Split on the first `:` to separate intent from optional topic.
+        if ":" in cleaned:
+            intent_part, _, topic_part = cleaned.partition(":")
+            intent_part = intent_part.strip()
+            topic_part = topic_part.strip()
+        else:
+            intent_part = cleaned
+            topic_part = ""
+
+        if intent_part in valid:
+            intent = intent_part
         else:
             # Last resort: pick the first valid token that appears as a
             # whole word in the reply. Handles "intent: question" style.
             words = re.findall(r"[a-z_]+", cleaned)
             intent = next((w for w in words if w in valid), "log_text")
+
+        # Only `question:weight` is recognised. Any other topic suffix is
+        # silently ignored — we'd rather miss a topic than misroute on
+        # garbage. Defensive against Haiku outputting "question:other" /
+        # "question:food" etc., which we don't (yet) act on.
+        topic: Optional[str] = None
+        if intent == "question" and topic_part == "weight":
+            topic = "weight"
+
         log.info(
             f"detect_intent history_len={history_len} "
-            f"last_user={text[:80]!r} raw={raw!r} intent={intent}"
+            f"last_user={text[:80]!r} raw={raw!r} intent={intent} topic={topic}"
         )
-        return intent
+        return intent, topic
     except Exception:
         t = text.lower()
         # Correction-ish verbs in English + Russian. The "change" / "поменя" /
@@ -939,10 +1027,12 @@ def detect_intent(text: str, history: Optional[list[dict]] = None) -> str:
             "исправ", "удали", "помен", "измени",
         ]
         if any(s in t for s in correction_keywords):
-            return "correction"
+            return "correction", None
         if t.endswith("?") or any(t.startswith(s) for s in ["how", "what", "сколько"]):
-            return "question"
-        return "log_text"
+            # No semantic topic detection in the fallback path — when the
+            # API is down anyway the snapshot-only weight context is fine.
+            return "question", None
+        return "log_text", None
 
 
 def extract_query_date(text: str, today_str: str) -> tuple[str, str]:

--- a/database.py
+++ b/database.py
@@ -1220,6 +1220,40 @@ def get_latest_weight_reading(user_id: int) -> Optional[dict]:
     return dict(row) if row else None
 
 
+def get_lifetime_weight_stats(user_id: int) -> Optional[dict]:
+    """Overall summary across all weight readings for this user — useful for
+    "lowest weight ever", "average over my entire history", "how long have
+    I been tracking?" type questions.
+
+    Returns None if there are no readings. Otherwise:
+        {
+            "avg_kg":   float,
+            "min_kg":   float,
+            "max_kg":   float,
+            "count":    int,
+            "first_at": ISO timestamp of the earliest reading,
+            "last_at":  ISO timestamp of the most recent reading,
+        }
+    """
+    conn = get_conn()
+    row = conn.execute(
+        """SELECT
+               AVG(weight_kg)   AS avg_kg,
+               MIN(weight_kg)   AS min_kg,
+               MAX(weight_kg)   AS max_kg,
+               COUNT(*)         AS count,
+               MIN(measured_at) AS first_at,
+               MAX(measured_at) AS last_at
+           FROM weight_readings
+           WHERE user_id = ?""",
+        (user_id,),
+    ).fetchone()
+    conn.close()
+    if not row or row["count"] == 0:
+        return None
+    return dict(row)
+
+
 def get_daily_min_weights(
     user_id: int,
     since: Optional[str] = None,

--- a/telegram_bot.py
+++ b/telegram_bot.py
@@ -798,8 +798,8 @@ async def handle_text(update: Update, ctx: ContextTypes.DEFAULT_TYPE):
             return
         # else: user wrote about something unrelated — continue to the router.
 
-    intent = analyzer.detect_intent(text, history=history)
-    log.info(f"user={user_id} intent={intent} text={text[:60]}")
+    intent, topic = analyzer.detect_intent(text, history=history)
+    log.info(f"user={user_id} intent={intent} topic={topic} text={text[:60]}")
 
     # ── iPhone Shortcut: health snapshot (steps + weight) ────────────────────
     if intent == "health_update":
@@ -1207,7 +1207,10 @@ async def handle_text(update: Update, ctx: ContextTypes.DEFAULT_TYPE):
     # ── Question ─────────────────────────────────────────────────────────────
     if intent == "question":
         async def _work_question():
-            answer = advisor.answer_question(user_id, text, conversation=history)
+            # topic comes from detect_intent — passes through as-is to
+            # answer_question, which decides whether to load the heavy
+            # weight history into Sonnet's prompt.
+            answer = advisor.answer_question(user_id, text, conversation=history, topic=topic)
             await _send(update, _safe_reply(answer), parse_mode=ParseMode.MARKDOWN)
             # Fire-and-forget: let Haiku decide whether this question reveals
             # something about the user worth filing (usually a self-concern like


### PR DESCRIPTION
Closes #24.

Two issues bundled, plus the design upgrade from Maria's feedback on the first draft of this PR:

1. INTENT ROUTING BUG. "Tell me my weight in April" was hitting the broad "ANY mention of a specific past day → cmd_date_query" rule and getting routed to day_summary (meal log + activity), which showed Maria food data instead of weight data. Tightened the intent prompt so: - cmd_date_query is now explicitly FOOD-ONLY for past days - Weight/body-metric questions are always `question`, even with a date / month / week mentioned - Added a dozen explicit weight-question examples covering the shapes users actually ask.

2. STATISTICAL FLEXIBILITY. Pre-baking specific aggregations (monthly, yearly, etc.) doesn't scale — users ask any shape of question ("split by week", "median", "Q3 average"). Give Sonnet the canonical daily-min series and let it compute. Snapshot + lifetime summary remain pre-computed (small + accurate).

3. SEMANTIC GATING via intent classifier topic tag. The first draft used a keyword check (`weight`, `kg`, `lose`, etc.) to decide whether to load the heavy weight history into Sonnet's prompt. That misses synonyms — "show me my body progress", "how am I changing physically", "am I getting leaner" — none contain the keywords. Fixed by extending the existing detect_intent Haiku call to optionally append a `:weight` topic suffix when the question is semantically about weight/body. Free (same Haiku call), zero added latency, semantic-quality classification.

Code:

  - analyzer.py:
    * INTENT_SYSTEM_PROMPT: new cmd_date_query scope (food-only), new weight-question examples, new OUTPUT FORMAT section explaining the optional `:weight` suffix with positive + negative examples.
    * detect_intent: now returns `(intent, topic)` tuple. Parses `intent:topic` from Haiku's reply, validates each half independently, silently drops unknown topics, falls back to the existing word-search if intent isn't recognised. max_tokens bumped from 10 to 12 to fit "question:weight". API-error fallback path also returns tuples now.

  - telegram_bot.py:
    * handle_text: unpacks the new tuple, passes `topic` to answer_question. Logs both intent and topic.

  - advisor.py:
    * answer_question: accepts new `topic: Optional[str]` kwarg; include_history = (topic == "weight").
    * _fmt_weight_context_for_prompt: include_history flag drives the heavy daily-history section. Snapshot + lifetime always sent (small, ~200 tokens). Daily history only when caller opts in. evening_summary: never. weekly_review: always. answer_question: only when topic == "weight".
    * Removed the keyword-based `_is_weight_question` and the `_WEIGHT_QUESTION_KEYWORDS` tuple — superseded by the semantic topic tag.

  - database.py: get_lifetime_weight_stats(user_id) added (used by the snapshot section). Pre-baked monthly/yearly helpers drafted earlier in this branch were dropped — the daily-min series covers any user-requested aggregation.

  - ARCHITECTURE.md: §4 message routing table updated (cmd_date_query is food-only); §7.5 detect_intent rewritten to document the tuple return and topic-tag mechanism; §8.3A weight helpers section updated to reflect the topic-driven gating (replacing the keyword check).

Smoke tests (in-band, no API calls): parsing handles 15 edge cases — "question:weight" → ("question", "weight"); "question:food" → ("question", None) (unknown topic silently dropped); "correction:weight" → ("correction", None) (topic only for question); case-insensitive + whitespace + backtick + quote decoration all stripped; "garbage" → ("log_text", None); empty string handled.

Cost (Sonnet 4.6 at $3/M input + Haiku for intent):
  - 1-2 questions/day: ~$0.40/month
  - 5  questions/day: ~$1.00/month
  - 15 questions/day: ~$2.50/month Compared to ~$4-7/month for unconditional history injection.