### PR TITLE
Apple Health weight import — completes issue #20

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1543,6 +1543,43 @@ the bot). Walks through the Withings OAuth 2.0 authorization flow:
 Run: `python setup_withings.py --user <telegram_user_id>`. Required env
 vars must be set first.
 
+### `import_apple_health.py` — one-time backfill from Apple Health
+
+A separate, standalone script for importing weight history that lives
+outside the Withings API's reach. **Why we need it:** Apple Health
+merges weight data from many sources (Withings + manual entry +
+third-party scales + apps), but the Withings API itself only returns
+readings measured by Withings devices. So pre-Withings history (or any
+data synced in from a non-Withings source) needs Apple's export path.
+
+How it works:
+
+1. The user exports their Apple Health data from the iPhone Health app
+   (Profile → Export All Health Data), which produces a `.zip`
+   containing `apple_health_export/export.xml`.
+2. They transfer the ZIP to the server.
+3. They run: `python import_apple_health.py --user N --file export.zip`.
+
+Internals:
+
+- Streams the XML with `ET.iterparse` and `elem.clear()` to keep memory
+  bounded — Apple Health exports can exceed a gigabyte for several
+  years of dense data.
+- Filters for records with `type="HKQuantityTypeIdentifierBodyMass"`.
+- Converts the unit attribute to kg via a small lookup table
+  (`kg` / `g` / `lb` / `lbs` supported).
+- Parses Apple's `YYYY-MM-DD HH:MM:SS ±HHMM` date format into ISO UTC.
+- Inserts each reading via `db.insert_weight_reading` with
+  `source="apple_health"` so the import path is identifiable.
+- Idempotent via the DB's `UNIQUE(user_id, measured_at)` constraint —
+  re-running is a silent no-op for already-present readings.
+- `--dry-run` prints the count without writing.
+
+For zips, the script matches the inner XML by **exact basename**
+(`export.xml`), not by suffix — Apple's archive also contains
+`export_cda.xml` and other siblings that would otherwise match a
+naive `.endswith("export.xml")` check.
+
 ### `withings_sync.py` — hourly polling
 
 Run by cron. For every user in `withings_auth`:

--- a/README.md
+++ b/README.md
@@ -224,6 +224,37 @@ python withings_sync.py --user <your_telegram_user_id> --since 2020-06-01
 Typical run for 5 years of history takes a minute or two and logs each
 chunk to `withings.log`.
 
+**Important limitation:** the Withings API only returns readings *measured
+by Withings devices*. If your Withings app shows older data that was synced
+in from Apple Health (or another scale), that data is NOT reachable via the
+Withings API — see the next step.
+
+### 6. (Optional) Import older data from Apple Health
+
+If you have weight history in Apple Health from before your Withings
+setup, export from Apple Health and import that:
+
+1. On your iPhone: open **Health** → tap your profile picture (top right)
+   → scroll to the bottom → **Export All Health Data**.
+2. iOS produces a `.zip` (typically `export.zip`). Transfer it to the
+   server — e.g. AirDrop to your Mac, then:
+   ```bash
+   scp export.zip root@<your-server-ip>:/opt/nutrition-bot/
+   ```
+3. Run the importer:
+   ```bash
+   python import_apple_health.py --user <your_telegram_user_id> --file export.zip
+   ```
+
+The script streams the XML (no memory issue even on multi-GB exports),
+normalizes the unit (kg / lb / g all handled), and inserts every weight
+reading with `source="apple_health"` so they're distinguishable from
+Withings API readings. Idempotent — `UNIQUE(user_id, measured_at)`
+silently skips anything you already have.
+
+Use `--dry-run` to see how many records would be imported without
+writing anything.
+
 ## Commands
 
 | Command | What it does |

--- a/import_apple_health.py
+++ b/import_apple_health.py
@@ -1,0 +1,217 @@
+"""
+import_apple_health.py — One-time bulk import of weight history from
+an Apple Health export.
+
+Why this exists (issue #20): Apple Health stores weight data merged from
+multiple sources (Withings, manual entry, third-party apps, …). The
+Withings API itself only returns readings measured by Withings devices,
+so historical readings from before your current Withings setup are
+unreachable through `withings_sync.py`. Apple Health, however, retains
+everything — exporting from there and importing here is the simplest
+way to backfill pre-Withings history.
+
+Usage:
+    # 1. On your iPhone: open the Health app → tap your profile picture
+    #    (top right) → scroll to "Export All Health Data".
+    # 2. iOS produces a ZIP (typically named "export.zip"). Transfer it
+    #    to the server (AirDrop to Mac → scp, for example).
+    # 3. Run this script:
+    python import_apple_health.py --user 264886463 --file export.zip
+
+The DB's UNIQUE(user_id, measured_at) constraint makes the script
+idempotent — re-running won't double-insert. Readings get the source
+tag "apple_health" so they're distinguishable from withings_api ones.
+"""
+
+import argparse
+import logging
+import sys
+import xml.etree.ElementTree as ET
+import zipfile
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Optional, BinaryIO
+
+import database as db
+
+# Apple Health record type for weight measurements.
+WEIGHT_TYPE = "HKQuantityTypeIdentifierBodyMass"
+
+# Conversion factors to kilograms. Apple may export in different units
+# depending on the phone's region/settings.
+_TO_KG = {
+    "kg": 1.0,
+    "g": 0.001,
+    "lb": 0.45359237,
+    "lbs": 0.45359237,
+}
+
+log = logging.getLogger("apple_health_import")
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s [%(levelname)s] %(message)s",
+)
+
+
+def _parse_apple_date(s: str) -> Optional[str]:
+    """'2022-03-15 07:42:00 +0100' → '2022-03-15T06:42:00Z' (UTC ISO).
+
+    Returns None on any parse failure — caller skips the record.
+    """
+    if not s:
+        return None
+    try:
+        dt = datetime.strptime(s, "%Y-%m-%d %H:%M:%S %z")
+        return dt.astimezone(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+    except (ValueError, TypeError):
+        return None
+
+
+def _to_kg(value_str: Optional[str], unit: Optional[str]) -> Optional[float]:
+    """Convert to kilograms. Returns None for unknown units or bad numbers."""
+    if value_str is None:
+        return None
+    try:
+        value = float(value_str)
+    except (TypeError, ValueError):
+        return None
+    factor = _TO_KG.get((unit or "").lower())
+    if factor is None:
+        return None
+    return value * factor
+
+
+def _open_export_xml(file_path: Path) -> BinaryIO:
+    """Return a binary file-like for the export.xml inside `file_path`.
+    Handles both the raw `.xml` file and the iOS ZIP-export format
+    (the latter contains `apple_health_export/export.xml` plus other
+    sibling files like `export_cda.xml` — we match the basename
+    exactly so we don't grab the wrong one).
+    """
+    if zipfile.is_zipfile(file_path):
+        zf = zipfile.ZipFile(file_path)
+        candidates = [n for n in zf.namelist() if Path(n).name == "export.xml"]
+        if not candidates:
+            zf.close()
+            raise RuntimeError(
+                f"No export.xml found inside {file_path}. "
+                f"First 5 entries: {zf.namelist()[:5]}"
+            )
+        # zf stays implicitly open as long as the inner stream is open; the
+        # caller calls .close() on the returned stream, which closes the
+        # zipfile descriptor too.
+        return zf.open(candidates[0])
+    return open(file_path, "rb")
+
+
+def import_file(
+    user_id: int,
+    file_path: Path,
+    dry_run: bool = False,
+) -> dict:
+    """Stream-parse the XML and write each weight record. Returns stats."""
+    if not file_path.exists():
+        raise FileNotFoundError(file_path)
+
+    total = 0
+    inserted = 0
+    skipped_dup = 0
+    skipped_bad = 0
+    earliest: Optional[str] = None
+    latest: Optional[str] = None
+
+    stream = _open_export_xml(file_path)
+    try:
+        # iterparse + elem.clear() keeps memory bounded for multi-GB
+        # exports. Several years of Apple Health data can easily exceed
+        # a gigabyte of XML.
+        for event, elem in ET.iterparse(stream, events=("end",)):
+            if elem.tag != "Record" or elem.attrib.get("type") != WEIGHT_TYPE:
+                elem.clear()
+                continue
+
+            total += 1
+            value_kg = _to_kg(elem.attrib.get("value"), elem.attrib.get("unit"))
+            measured_at = _parse_apple_date(elem.attrib.get("startDate"))
+            elem.clear()   # release the record's memory ASAP
+
+            if value_kg is None or measured_at is None:
+                skipped_bad += 1
+                continue
+
+            if earliest is None or measured_at < earliest:
+                earliest = measured_at
+            if latest is None or measured_at > latest:
+                latest = measured_at
+
+            if dry_run:
+                continue
+
+            if db.insert_weight_reading(
+                user_id=user_id,
+                measured_at=measured_at,
+                weight_kg=value_kg,
+                source="apple_health",
+            ):
+                inserted += 1
+            else:
+                skipped_dup += 1
+
+            if total % 1000 == 0:
+                log.info(
+                    f"...processed {total} weight records "
+                    f"(new={inserted}, dups={skipped_dup}, bad={skipped_bad})"
+                )
+    finally:
+        stream.close()
+
+    return {
+        "total": total,
+        "inserted": inserted,
+        "skipped_duplicates": skipped_dup,
+        "skipped_bad": skipped_bad,
+        "earliest": earliest,
+        "latest": latest,
+    }
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="One-time import of weight history from Apple Health export",
+    )
+    parser.add_argument("--user", type=int, required=True,
+                        help="Telegram user_id to import readings to.")
+    parser.add_argument("--file", type=str, required=True,
+                        help="Path to Apple Health export (ZIP or XML).")
+    parser.add_argument("--dry-run", action="store_true",
+                        help="Parse + count, do NOT write to the DB.")
+    args = parser.parse_args()
+
+    db.init_db()
+    db.ensure_user(args.user)
+
+    file_path = Path(args.file).expanduser()
+    log.info(f"User {args.user}: importing from {file_path}")
+    if args.dry_run:
+        log.info("DRY RUN — no rows will be written")
+
+    try:
+        stats = import_file(args.user, file_path, dry_run=args.dry_run)
+    except FileNotFoundError as e:
+        log.error(f"File not found: {e}")
+        sys.exit(1)
+    except RuntimeError as e:
+        log.error(str(e))
+        sys.exit(1)
+
+    log.info("───── Summary ─────")
+    log.info(f"  Weight records found:   {stats['total']}")
+    log.info(f"  Newly inserted:         {stats['inserted']}")
+    log.info(f"  Skipped (duplicate):    {stats['skipped_duplicates']}")
+    log.info(f"  Skipped (bad value):    {stats['skipped_bad']}")
+    if stats["earliest"]:
+        log.info(f"  Date range:             {stats['earliest']} → {stats['latest']}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Closes #20.

This is the missing third piece of the historical weight backfill, after PR A (#21, plumbing), PR B (#22, summary surfacing), and #23 (chunked Withings API import). The Withings API only returns readings measured by Withings devices, so any older history merged into the Withings app from Apple Health or other sources is unreachable through that path. Apple Health's own export, however, retains everything — which is where the pre-Withings history actually lives for users like Maria who used a non-Withings scale before switching.

Standalone script `import_apple_health.py`:

  - CLI: `--user N`, `--file PATH` (ZIP or XML), optional `--dry-run`.
  - Streams the XML via `ET.iterparse` with `elem.clear()` so memory stays bounded even on multi-GB exports.
  - Handles both formats Apple produces: the raw `.xml` file and the standard iOS `.zip` (which contains `apple_health_export/export.xml` plus other siblings).
  - Matches the inner XML by EXACT basename (`export.xml`), not by suffix — Apple's archive also ships `export_cda.xml` and a naive suffix check would pull the wrong file.
  - Filters records to `type="HKQuantityTypeIdentifierBodyMass"`.
  - Unit conversion via a small lookup: `kg` (×1), `g` (÷1000), `lb`/`lbs` (×0.45359237).
  - Apple's date format `YYYY-MM-DD HH:MM:SS ±HHMM` parsed to ISO UTC.
  - Inserts via `db.insert_weight_reading(source="apple_health")` so the import path is distinguishable from Withings API readings.
  - Idempotent via the existing `UNIQUE(user_id, measured_at)` constraint — re-running is a silent no-op for already-present rows.
  - Per-1000-record progress log; final summary with date range and breakdowns (inserted / duplicate / bad).

Smoke-tested with a synthetic Apple Health-style XML containing:
  - One kg reading      → imported correctly
  - One lb reading      → unit-converted: 148.5 lb → 67.3585 kg ✓
  - One step record     → skipped (not BodyMass)
  - One malformed date  → counted as skipped_bad

Three cases pass:
  1. Bare XML file path
  2. iOS ZIP format (correctly skips export_cda.xml decoy via exact-basename match)
  3. Re-run idempotency (second invocation: 0 inserted, 2 dedup'd)

README §6 added with the full export → AirDrop → scp → run flow. ARCHITECTURE.md §11A documents the script: why it exists alongside withings_sync.py, how it streams, the unit/date conversion, the exact-basename trick, and the idempotency guarantee.