### PR TITLE
Switch photo vision from Opus 4.6 to Sonnet 4.6 (issue #26 cost cut)

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -805,11 +805,19 @@ on photos, text-to-nutrition, intent classification, correction
 resolution), parsing iPhone Shortcut messages, and one-off LLM helpers
 (date extraction, profile updates, activity calorie estimates).
 
-Model choice is consistent: vision uses `claude-opus-4-6` (best image
-understanding); text food parsing, intent, correction, date extraction,
-profile updates, and activity estimation use `claude-haiku-4-5` (cheap,
-fast, narrow tasks). Sonnet 4.6 is reserved for `advisor.py`'s
-open-ended reasoning.
+Model choice (after issue #26 cost-cut):
+
+- **Vision** (`analyze_food_photo`, `analyze_label_photo`) uses
+  `claude-sonnet-4-6`. Originally Opus 4.6 for best-in-class vision,
+  swapped to Sonnet to cut ~$3/month — Sonnet has vision too, with a
+  small accuracy gap on tricky multi-component plates that's been
+  judged worth the cost reduction. Easy single-line revert (in
+  `analyzer.py`) if quality drops too far in real use.
+- **Text food parsing, intent, correction, date extraction, profile
+  updates, activity estimation, ingest, lint, contradictions** use
+  `claude-haiku-4-5` (cheap, fast, narrow tasks).
+- **Open-ended reasoning** (`weekly_review`, `evening_summary`,
+  `answer_question`) uses `claude-sonnet-4-6`.
 
 ### 7.1 System prompts
 

--- a/analyzer.py
+++ b/analyzer.py
@@ -370,7 +370,12 @@ def analyze_food_photo(
     """
     user_text = caption or "Please analyze this food photo."
     response = client.messages.create(
-        model="claude-opus-4-6",
+        # Sonnet 4.6 (was Opus 4.6) — issue #26 cost cut. ~5x cheaper on
+        # input + output. Sonnet has vision too; slight accuracy gap vs
+        # Opus on tricky multi-component plates, big enough cost gap that
+        # the tradeoff is worth it. Revert this single line if quality
+        # drops too far in practice.
+        model="claude-sonnet-4-6",
         max_tokens=1024,
         system=FOOD_SYSTEM_PROMPT,
         messages=[
@@ -404,7 +409,10 @@ def analyze_label_photo(
     """
     user_text = caption or "Please read this nutrition label."
     response = client.messages.create(
-        model="claude-opus-4-6",
+        # Sonnet 4.6 (was Opus 4.6) — issue #26 cost cut. Labels are simpler
+        # OCR than food plates, so Sonnet's accuracy here is even closer to
+        # Opus's than for food photos.
+        model="claude-sonnet-4-6",
         max_tokens=512,
         system=LABEL_SYSTEM_PROMPT,
         messages=[


### PR DESCRIPTION
Closes #26.

Per the May Anthropic console breakdown ($11.57 / month split roughly evenly across Haiku $3.98, Sonnet ~$4, Opus ~$4), Opus on photo vision is one of the three cost peaks. Sonnet has vision too and is ~5× cheaper on both input and output. Expected saving ~$3/month.

Changes:
  - analyze_food_photo: model="claude-sonnet-4-6" (was opus-4-6)
  - analyze_label_photo: model="claude-sonnet-4-6" (was opus-4-6)
  - ARCHITECTURE.md: model-choice paragraph in §7 updated to reflect the new vision model + the rationale for the swap, with an explicit "revert one line if quality drops" note for future-you.

Risk acknowledged: Sonnet may be slightly less accurate than Opus on tricky multi-component plates (busy buffets, overlapping items, low light). Labels are simpler OCR so the accuracy gap there is even smaller. If real-world quality drops too far, the revert is a two-line edit — same lines as this PR, just swap the strings back.

No other model usages touched: Haiku 4.5 still handles intent / correction / ingest / lint / contradictions / text food parsing / activity calorie estimation; Sonnet 4.6 still handles evening_summary analysis, weekly_review prose, and answer_question.