### PR TITLE
Skip inactive users in cron pushes + smoothed weekly weight delta

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -655,6 +655,15 @@ Workouts JSON is parsed back into a list automatically.
 `get_latest_weight` returns the most recently recorded weight for
 activity-calorie estimation.
 
+#### `user_has_recent_activity(user_id, days=7) → bool`
+True if the user has logged a meal (excluding soft-deleted) OR has any
+`weight_readings` row in the last `days` days. Used by the cron pushes
+(issue #29) to skip silent users — no Anthropic call, no Telegram push
+for someone who hasn't engaged in a week. Re-activates automatically
+the next cron tick after the user logs again. The OR makes it possible
+for a user who only ever weighs in (no meal logging) to still receive
+their weekly review.
+
 ### 5.9 Short-term conversation memory
 
 #### `log_message(user_id, role, content)`
@@ -1037,10 +1046,19 @@ readings. Returns a dict with `current_kg` (today's morning-low if
 available), `yesterday_kg`, `week_ago_kg`, `month_ago_kg`, their signed
 deltas, `target_kg` (from `goals.md`), `delta_target`,
 `pace_kg_per_wk` (linear end-to-end trend over the window, only if ≥14
-days of data), and `history` (the raw per-date min series).
+days of data), `this_week_avg_kg` (mean of daily-min readings over the
+last 7 days), `last_week_avg_kg` (mean over the preceding 7 days),
+`delta_week_avg` (`this_week_avg_kg - last_week_avg_kg`), and `history`
+(the raw per-date min series).
 
 The "look up the weight at N days ago" uses a ±2-day search window so
 we don't return None just because the user skipped a weighing.
+
+The smoothed `this_week_avg_kg` / `last_week_avg_kg` pair (issue #29)
+is preferred over the point-to-point `week_ago_kg → current_kg`
+comparison in the weekly review, because single-day readings are noisy
+(day-to-day swings of ±0.3–0.5 kg are normal even on a flat trend).
+Averaging both endpoints over 7 days gives a much steadier signal.
 
 #### `_fmt_arrow_delta(delta, unit="kg") → str`
 
@@ -1054,9 +1072,12 @@ string if there's no data.
 
 - `mode="evening"` — compact: current weight, day + week deltas on one
   line, target distance.
-- `mode="weekly"` — richer: week start→current, month delta, target
-  distance, and a "pace per month + weeks-to-target" projection when
-  the trend is heading toward the target.
+- `mode="weekly"` — richer: smoothed week comparison (this-week avg vs
+  last-week avg — issue #29), month delta, target distance, and a
+  "pace per month + weeks-to-target" projection when the trend is
+  heading toward the target. Falls back to the point-to-point
+  `week_ago_kg → current_kg` line if the user has too few readings for
+  a full 7-day average on either side.
 
 #### `_fmt_weight_context_for_prompt(user_id, include_history=False) → str`
 
@@ -1493,17 +1514,24 @@ pending retry per user. A new user message cancels the previous task.
 
 - `_push_to_all_users(message_fn, bot)` — iterate over every `users`
   row, call `message_fn(user_id) → text`, send via Telegram. Silent on
-  per-user failures.
+  per-user failures. **Skips inactive users** (issue #29): before
+  calling `message_fn`, checks `db.user_has_recent_activity(uid, days=7)`.
+  Users who haven't logged a meal OR recorded a weight reading in the
+  past 7 days are skipped — no Anthropic call, no Telegram push.
+  Re-activates automatically the next cron tick after they resume
+  logging.
 - `run_daily_summary`, `run_evening_summary`, `run_weekly_review` —
   wrappers over `_push_to_all_users` that select the appropriate
-  advisor function.
+  advisor function. Inherit the inactive-user skip from the helper.
 - `_format_contradiction_dm(c) → str` — friendly DM body for an OPEN
   contradiction. Uses Haiku's `ask` field; falls back to plain rendering
   for legacy sections.
 - `run_lint_cron()` — Saturday 10:05 Berlin job. For every user: lint
   the wiki, detect new contradictions, record new ones, DM the oldest
   open. After the per-user loop, runs
-  `db.purge_conversation_older_than(14)` once globally.
+  `db.purge_conversation_older_than(14)` once globally. Applies the
+  same `user_has_recent_activity(uid, days=7)` skip directly (this
+  function iterates users itself rather than via `_push_to_all_users`).
 
 ### 11.5 `main()`
 

--- a/advisor.py
+++ b/advisor.py
@@ -782,6 +782,14 @@ def _weight_context(user_id: int) -> dict:
         "current_kg": None, "yesterday_kg": None,
         "week_ago_kg": None, "month_ago_kg": None,
         "delta_day": None, "delta_week": None, "delta_month": None,
+        # Smoothed weekly averages (issue #29) — less noisy than the
+        # point-to-point week_ago_kg/cur comparison. Each is the mean of
+        # available daily-min readings in a 7-day window:
+        #   this_week_avg_kg : days  0–6  (today + 6 days back)
+        #   last_week_avg_kg : days  7–13 (7 to 13 days back)
+        # delta_week_avg = this_week_avg_kg - last_week_avg_kg.
+        "this_week_avg_kg": None, "last_week_avg_kg": None,
+        "delta_week_avg": None,
         "target_kg": None, "delta_target": None,
         "pace_kg_per_wk": None,
         "history": [],
@@ -841,6 +849,24 @@ def _weight_context(user_id: int) -> dict:
         if out["month_ago_kg"] is not None:
             out["delta_month"] = out["current_kg"] - out["month_ago_kg"]
 
+    # ── Smoothed weekly averages (issue #29) ────────────────────────────────
+    # The point-to-point week_ago vs current comparison is noisy — one
+    # unusually high/low morning on either side throws the delta off. The
+    # average-of-7-days vs average-of-the-7-before is much more stable.
+    def _avg_in_window(days_back_start: int, days_back_end: int) -> Optional[float]:
+        """Average of daily-min readings for the inclusive window
+        [today - days_back_end, today - days_back_start]."""
+        end_d = (today - timedelta(days=days_back_start)).isoformat()
+        start_d = (today - timedelta(days=days_back_end)).isoformat()
+        vals = [r["weight_kg"] for r in history
+                if start_d <= r["date"] <= end_d]
+        return sum(vals) / len(vals) if vals else None
+
+    out["this_week_avg_kg"] = _avg_in_window(0, 6)    # today + 6 days back
+    out["last_week_avg_kg"] = _avg_in_window(7, 13)   # 7 to 13 days back
+    if out["this_week_avg_kg"] is not None and out["last_week_avg_kg"] is not None:
+        out["delta_week_avg"] = out["this_week_avg_kg"] - out["last_week_avg_kg"]
+
     # Pace: linear weekly trend from the oldest reading in the window to the
     # current. Simple end-to-end average; doesn't try to be clever about
     # short-term noise. Only computed if we have at least 14 days of data.
@@ -896,9 +922,22 @@ def _fmt_weight_block(user_id: int, mode: str = "evening") -> str:
     lines: list[str] = []
 
     if mode == "weekly":
-        # Header: this-week start → current, plus one-line delta.
-        wk = ctx["week_ago_kg"]
-        if wk is not None:
+        # Header: prefer the smoothed week-vs-week average comparison (issue
+        # #29) — the avg-of-7-days vs avg-of-the-7-before is much less noisy
+        # than picking single readings 7 days apart, which can swing
+        # significantly on one unusual morning.
+        this_avg = ctx.get("this_week_avg_kg")
+        last_avg = ctx.get("last_week_avg_kg")
+        if this_avg is not None and last_avg is not None:
+            lines.append(
+                f"⚖️ Weight: *{cur:.1f} kg now* "
+                f"(this week avg {this_avg:.1f}, last week avg {last_avg:.1f} — "
+                f"{_fmt_arrow_delta(this_avg - last_avg)})"
+            )
+        elif ctx["week_ago_kg"] is not None:
+            # Fallback to point-to-point if we don't have ≥1 reading in each
+            # of the two 7-day windows yet (new user, sparse data).
+            wk = ctx["week_ago_kg"]
             lines.append(f"⚖️ Weight: *{wk:.1f} → {cur:.1f} kg* this week ({_fmt_arrow_delta(cur - wk)})")
         else:
             lines.append(f"⚖️ Weight: *{cur:.1f} kg*")
@@ -986,6 +1025,13 @@ def _fmt_weight_context_for_prompt(
         parts.append(f"yesterday {ctx['yesterday_kg']:.1f} kg")
     if ctx["week_ago_kg"] is not None:
         parts.append(f"a week ago {ctx['week_ago_kg']:.1f} kg")
+    # Smoothed weekly averages (issue #29) — more stable than picking
+    # single readings 7 days apart for the week-over-week comparison.
+    if ctx["this_week_avg_kg"] is not None and ctx["last_week_avg_kg"] is not None:
+        parts.append(
+            f"this week avg {ctx['this_week_avg_kg']:.1f} kg, "
+            f"last week avg {ctx['last_week_avg_kg']:.1f} kg"
+        )
     if ctx["month_ago_kg"] is not None:
         parts.append(f"a month ago {ctx['month_ago_kg']:.1f} kg")
     if ctx["pace_kg_per_wk"] is not None:

--- a/database.py
+++ b/database.py
@@ -1220,6 +1220,46 @@ def get_latest_weight_reading(user_id: int) -> Optional[dict]:
     return dict(row) if row else None
 
 
+def user_has_recent_activity(user_id: int, days: int = 7) -> bool:
+    """True if the user has logged at least one non-deleted meal OR has any
+    weight reading in the last `days` days.
+
+    Used by the cron entry points (evening summary, weekly review, Saturday
+    lint) to skip users who aren't actively using the bot — saves Anthropic
+    tokens we'd otherwise burn summarising empty data for inactive accounts
+    (issue #29).
+
+    "Active" is a broad definition (meals OR weight) so we don't accidentally
+    skip a user who tracks weight via Withings but doesn't log food. For the
+    common case (someone who fully stops using the bot for >7 days), both
+    sources are dry and the user is correctly classified inactive.
+    """
+    cutoff = (date.today() - timedelta(days=int(days))).isoformat()
+    conn = get_conn()
+
+    meal_row = conn.execute(
+        """SELECT 1 FROM meals
+           WHERE user_id = ?
+             AND date(logged_at) >= ?
+             AND confidence != 'deleted'
+           LIMIT 1""",
+        (user_id, cutoff),
+    ).fetchone()
+    if meal_row:
+        conn.close()
+        return True
+
+    weight_row = conn.execute(
+        """SELECT 1 FROM weight_readings
+           WHERE user_id = ?
+             AND date(measured_at) >= ?
+           LIMIT 1""",
+        (user_id, cutoff),
+    ).fetchone()
+    conn.close()
+    return weight_row is not None
+
+
 def get_lifetime_weight_stats(user_id: int) -> Optional[dict]:
     """Overall summary across all weight readings for this user — useful for
     "lowest weight ever", "average over my entire history", "how long have

--- a/telegram_bot.py
+++ b/telegram_bot.py
@@ -1247,8 +1247,14 @@ async def handle_text(update: Update, ctx: ContextTypes.DEFAULT_TYPE):
 
 async def _push_to_all_users(message_fn, bot):
     """
-    Call message_fn(user_id) → text, send to every registered user.
+    Call message_fn(user_id) → text, send to every ACTIVE registered user.
     message_fn receives user_id and returns a string.
+
+    Inactive users (no meals or weight readings in the past 7 days) are
+    skipped so we don't burn Anthropic tokens summarising empty data for
+    accounts that aren't really using the bot — see issue #29. The skip
+    is automatic; if an inactive user starts logging again, the next
+    cron tick picks them back up without any flag-flipping.
     """
     from database import get_conn
     conn = get_conn()
@@ -1257,6 +1263,9 @@ async def _push_to_all_users(message_fn, bot):
 
     for row in users:
         uid = row["user_id"]
+        if not db.user_has_recent_activity(uid, days=7):
+            log.info(f"Skipping push to inactive user {uid} (no activity in 7 days)")
+            continue
         try:
             text = message_fn(uid)
             await bot.send_message(
@@ -1348,6 +1357,12 @@ async def run_lint_cron():
 
     for row in users:
         uid = row["user_id"]
+        # Skip inactive users (issue #29) — no lint pass, no contradiction
+        # detect call, no DM. Tokens saved when a registered user isn't
+        # really using the bot.
+        if not db.user_has_recent_activity(uid, days=7):
+            log.info(f"Skipping lint cron for inactive user {uid} (no activity in 7 days)")
+            continue
         try:
             # 1) Tidy first so we're detecting on a clean wiki.
             await lint.lint_user_wiki(uid)


### PR DESCRIPTION
Two related changes that together cut Anthropic spend on the daily/ weekly/Saturday-lint crons and make the weekly weight comparison less jittery.

1. Skip inactive users (issue #29)
   - New helper `db.user_has_recent_activity(user_id, days=7)` returns True if the user has any non-deleted meal OR any weight_readings row in the last 7 days.
   - `_push_to_all_users` checks it before calling `message_fn` — no Anthropic call, no Telegram push for someone who has gone quiet. This covers the daily summary, evening summary, and weekly review.
   - `run_lint_cron` applies the same skip directly (it iterates users itself rather than via `_push_to_all_users`).
   - Inactive users re-activate automatically the next cron tick after they resume logging — nothing to flip.
   - The OR (meals or weight) means a Withings-only user who never logs food still gets their weekly review.

2. Smoothed weekly weight comparison
   - `_weight_context` now also computes `this_week_avg_kg` (mean of daily-min readings days 0–6 back) and `last_week_avg_kg` (mean of days 7–13 back), plus `delta_week_avg`.
   - `_fmt_weight_block(mode="weekly")` prefers the smoothed averages in the weekly review header — much less noisy than picking single readings 7 days apart (which can swing by ±0.3–0.5 kg on one unusual morning).
   - Falls back to the existing point-to-point `week_ago_kg → current` line if the user has too few readings for a full 7-day average on either side (new user / sparse data).
   - The smoothed line also flows into `_fmt_weight_context_for_prompt` so Sonnet sees the steadier signal too.

ARCHITECTURE.md §5.8, §8.3A (_weight_context + _fmt_weight_block), §11.4 updated to document all of the above.

Closes #29